### PR TITLE
Add support for converting error bodies in HTTP 4xx responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ override fun responseBodyConverter(
   annotations: Array<out Annotation>,
   retrofit: Retrofit
 ): Converter<ResponseBody, *>? {
-  val (statusCode, nextAnnotations) = annotations.nextAnnotations()
+  val (statusCode, nextAnnotations) = annotations.statusCode()
     ?: return
   val errorType = when (statusCode.value) {
     401 -> Unauthorized::class.java

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ when (val result = myApi.someEndpoint()) {
     is NetworkFailure -> showError(result.error)
     is HttpFailure -> showError(result.code)
     is ApiFailure -> showError(result.error)
-    is UnknownError -> showError(result.error)
+    is UnknownFailure -> showError(result.error)
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ interface TestApi {
 }
 ```
 
-Now a 4xx response will try to decode its error body (if any) as `ErrorResponse`. If you want to
+Now a 4xx or 5xx response will try to decode its error body (if any) as `ErrorResponse`. If you want to
 contextually decode the error body based on the status code, you can retrieve a `@StatusCode` annotation
 from annotations in a custom Retrofit `Converter`.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ override fun responseBodyConverter(
   val (statusCode, nextAnnotations) = annotations.nextAnnotations()
     ?: return
   val errorType = when (statusCode.value) {
-    401 -> Unuuthorized::class.java
+    401 -> Unauthorized::class.java
     404 -> NotFound::class.java
     // ...
   }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ interface TestApi {
 }
 ```
 
-Now a 4xx response will try to decode its error body (if any) as `ErrorResponse`. If you want to 
+Now a 4xx response will try to decode its error body (if any) as `ErrorResponse`. If you want to
 contextually decode the error body based on the status code, you can retrieve a `@StatusCode` annotation
 from annotations in a custom Retrofit `Converter`.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,43 @@ val api = Retrofit.Builder()
 
 If you don't have custom error return types, simply use `Nothing` for the error type.
 
+### Decoding Error Bodies
+
+If you want to decode error types in `HttpFailure`s, annotate your endpoint with `@DecodeErrorBody`:
+
+```kotlin
+interface TestApi {
+  @DecodeErrorBody
+  @GET("/")
+  suspend fun getData(): ApiResult<SuccessResponse, ErrorResponse>
+}
+```
+
+Now a 4xx response will try to decode its error body (if any) as `ErrorResponse`. If you want to 
+contextually decode the error body based on the status code, you can retrieve a `@StatusCode` annotation
+from annotations in a custom Retrofit `Converter`.
+
+```kotlin
+// In your own converter factory.
+override fun responseBodyConverter(
+  type: Type,
+  annotations: Array<out Annotation>,
+  retrofit: Retrofit
+): Converter<ResponseBody, *>? {
+  val (statusCode, nextAnnotations) = annotations.nextAnnotations()
+    ?: return
+  val errorType = when (statusCode.value) {
+    401 -> Unuuthorized::class.java
+    404 -> NotFound::class.java
+    // ...
+  }
+  val errorDelegate = retrofit.nextResponseBodyConverter<Any>(this, errorType.toType(), nextAnnotations)
+  return MyCustomBodyConverter(errorDelegate)
+}
+```
+
+Note that error bodies with a content length of 0 will be skipped.
+
 ### Plugability
 
 A common pattern for some APIs is to return a polymorphic `200` response where the data needs to be
@@ -90,8 +127,7 @@ class ErrorConverterFactory : Converter.Factory() {
     retrofit: Retrofit
   ): Converter<ResponseBody, *>? {
     // This returns a `@ResultType` instance that can be used to get the error type via toType()
-    val (errorType, nextAnnotations) = annotations.nextAnnotations() ?: error(
-      "No error type found!")
+    val (errorType, nextAnnotations) = annotations.errorType() ?: error("No error type found!")
     return ResponseBodyConverter(errorType.toType())
   }
 

--- a/src/main/java/com/slack/eithernet/Annotations.kt
+++ b/src/main/java/com/slack/eithernet/Annotations.kt
@@ -32,7 +32,7 @@ import java.lang.reflect.WildcardType
  *   annotations: Array<out Annotation>,
  *   retrofit: Retrofit
  * ): Converter<ResponseBody, *>? {
- *   val (statusCode, nextAnnotations) = annotations.nextAnnotations()
+ *   val (statusCode, nextAnnotations) = annotations.statusCode()
  *     ?: return
  *   val errorType = when (statusCode) {
  *     401 -> Unuuthorized::class.java

--- a/src/main/java/com/slack/eithernet/Annotations.kt
+++ b/src/main/java/com/slack/eithernet/Annotations.kt
@@ -15,7 +15,6 @@
  */
 package com.slack.eithernet
 
-import com.slack.eithernet.ApiResult.Companion
 import com.slack.eithernet.Util.canonicalize
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type

--- a/src/main/java/com/slack/eithernet/Annotations.kt
+++ b/src/main/java/com/slack/eithernet/Annotations.kt
@@ -15,10 +15,39 @@
  */
 package com.slack.eithernet
 
+import com.slack.eithernet.ApiResult.Companion
 import com.slack.eithernet.Util.canonicalize
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.lang.reflect.WildcardType
+
+/**
+ * Returns a [Pair] of a [StatusCode] and subset of these annotations without that [StatusCode]
+ * instance. This should be used in a custom Retrofit [retrofit2.Converter.Factory] to know what
+ * the given status code of a non-2xx response was when decoding the error body. This can be useful
+ * for contextually decoding error bodies based on the status code.
+ *
+ * ```
+ * override fun responseBodyConverter(
+ *   type: Type,
+ *   annotations: Array<out Annotation>,
+ *   retrofit: Retrofit
+ * ): Converter<ResponseBody, *>? {
+ *   val (statusCode, nextAnnotations) = annotations.nextAnnotations()
+ *     ?: return
+ *   val errorType = when (statusCode) {
+ *     401 -> Unuuthorized::class.java
+ *     404 -> NotFound::class.java
+ *     // ...
+ *   }
+ *   val errorDelegate = retrofit.nextResponseBodyConverter<Any>(this, errorType.toType(), nextAnnotations)
+ *   return MyCustomBodyConverter(errorDelegate)
+ * }
+ * ```
+ */
+public fun Array<out Annotation>.statusCode(): Pair<StatusCode, Array<Annotation>>? {
+  return nextAnnotations(StatusCode::class.java)
+}
 
 /**
  * Returns a [Pair] of a [ResultType] and subset of these annotations without that [ResultType]
@@ -31,22 +60,27 @@ import java.lang.reflect.WildcardType
  *   annotations: Array<out Annotation>,
  *   retrofit: Retrofit
  * ): Converter<ResponseBody, *>? {
- *   val (errorType, nextAnnotations) = annotations.nextAnnotations()
+ *   val (errorType, nextAnnotations) = annotations.errorType()
  *     ?: error("No error type found!")
  *   val errorDelegate = retrofit.nextResponseBodyConverter<Any>(this, errorType.toType(), nextAnnotations)
  *   return MyCustomBodyConverter(errorDelegate)
  * }
  * ```
  */
-public fun Array<out Annotation>.nextAnnotations(): Pair<ResultType, Array<Annotation>>? {
+public fun Array<out Annotation>.errorType(): Pair<ResultType, Array<Annotation>>? {
+  return nextAnnotations(ResultType::class.java)
+}
+
+private fun <A> Array<out Annotation>.nextAnnotations(type: Class<A>): Pair<A, Array<Annotation>>? {
   var nextIndex = 0
   val theseAnnotations = this
-  var resultType: ResultType? = null
+  var resultType: A? = null
   val nextAnnotations = arrayOfNulls<Annotation>(size - 1)
   for (i in indices) {
     val next = theseAnnotations[i]
-    if (next is ResultType) {
-      resultType = next
+    if (type.isInstance(next)) {
+      @Suppress("UNCHECKED_CAST")
+      resultType = next as A
     } else {
       nextAnnotations[nextIndex] = next
       nextIndex++
@@ -91,6 +125,11 @@ public fun ResultType.toType(): Type {
   }
 }
 
+internal fun createStatusCode(code: Int): StatusCode {
+  ApiResult.checkHttpFailureCode(code)
+  return StatusCodeImpl(code)
+}
+
 internal fun createResultType(type: Type): ResultType {
   var ownerType: Type = Nothing::class.java
   val rawType: Class<*>
@@ -125,11 +164,9 @@ internal fun createResultType(type: Type): ResultType {
   )
 }
 
-internal fun createResultType(
+private fun createResultType(
   ownerType: Class<*>,
   rawType: Class<*>,
   typeArgs: Array<ResultType>,
   isArray: Boolean
-): ResultType {
-  return ResultTypeImpl(ownerType, rawType, typeArgs, isArray)
-}
+): ResultType = ResultTypeImpl(ownerType, rawType, typeArgs, isArray)

--- a/src/main/java/com/slack/eithernet/ApiResult.kt
+++ b/src/main/java/com/slack/eithernet/ApiResult.kt
@@ -204,7 +204,8 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
     }
 
     val decodeErrorBody = annotations.any { it is DecodeErrorBody }
-    return ApiResultCallAdapter(retrofit,
+    return ApiResultCallAdapter(
+      retrofit,
       apiResultType,
       decodeErrorBody,
       annotations
@@ -263,8 +264,10 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
                       }
                     }
                   }
-                  callback.onResponse(call,
-                    Response.success(ApiResult.httpFailure(response.code(), errorBody)))
+                  callback.onResponse(
+                    call,
+                    Response.success(ApiResult.httpFailure(response.code(), errorBody))
+                  )
                 }
               }
             }

--- a/src/main/java/com/slack/eithernet/ApiResult.kt
+++ b/src/main/java/com/slack/eithernet/ApiResult.kt
@@ -255,6 +255,7 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
                       val nextAnnotations = arrayOfNulls<Annotation>(annotations.size + 1)
                       nextAnnotations[0] = statusCode
                       annotations.copyInto(nextAnnotations, 1)
+                      @Suppress("TooGenericExceptionCaught")
                       errorBody = try {
                         retrofit.responseBodyConverter<Any>(errorType, nextAnnotations)
                           .convert(responseBody)

--- a/src/main/java/com/slack/eithernet/ApiResult.kt
+++ b/src/main/java/com/slack/eithernet/ApiResult.kt
@@ -15,10 +15,12 @@
  */
 package com.slack.eithernet
 
+import com.slack.eithernet.ApiResult.Failure
 import com.slack.eithernet.ApiResult.Failure.ApiFailure
 import com.slack.eithernet.ApiResult.Failure.HttpFailure
 import com.slack.eithernet.ApiResult.Failure.NetworkFailure
 import com.slack.eithernet.ApiResult.Failure.UnknownFailure
+import com.slack.eithernet.ApiResult.Success
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.CallAdapter
@@ -69,7 +71,7 @@ public sealed class ApiResult<out T, out E> {
      * degrade or retry.
      */
     public data class NetworkFailure internal constructor(
-      public val error: IOException
+      public val error: IOException,
     ) : Failure<Nothing>()
 
     /**
@@ -79,15 +81,19 @@ public sealed class ApiResult<out T, out E> {
      * gracefully degrade or retry.
      */
     public data class UnknownFailure internal constructor(
-      public val error: Throwable
+      public val error: Throwable,
     ) : Failure<Nothing>()
 
     /**
-     * An HTTP failure. This indicates a non-2xx response. The [code] is available for reference.
+     * An HTTP failure. This indicates a 4xx response. The [code] is available for reference.
      *
      * @property code The HTTP status code.
+     * @property error An optional [error][E]. This would be from the error body of the response.
      */
-    public data class HttpFailure internal constructor(public val code: Int) : Failure<Nothing>()
+    public data class HttpFailure<out E> internal constructor(
+      public val code: Int,
+      public val error: E?,
+    ) : Failure<E>()
 
     /**
      * An API failure. This indicates a 2xx response where [ApiException] was thrown
@@ -96,7 +102,7 @@ public sealed class ApiResult<out T, out E> {
      * An [ApiException], the [error] property will be best-effort populated with the
      * value of the [ApiException.error] property.
      *
-     * @property error An optional [error][E] type.
+     * @property error An optional [error][E].
      */
     public data class ApiFailure<out E> internal constructor(public val error: E?) : Failure<E>()
   }
@@ -104,14 +110,12 @@ public sealed class ApiResult<out T, out E> {
   public companion object {
     private const val OK = 200
     private val HTTP_SUCCESS_RANGE = OK..299
+    private val HTTP_FAILURE_RANGE = 400..499
 
-    /** Returns a new [HttpFailure] with given [code]. */
-    public fun httpFailure(code: Int): HttpFailure {
-      require(code !in HTTP_SUCCESS_RANGE) {
-        "Status code '$code' is a successful HTTP response. If you mean to use a $OK code + error " +
-          "string to indicate an API error, use the apiFailure() factory."
-      }
-      return HttpFailure(code)
+    /** Returns a new [HttpFailure] with given [code] and optional [error]. */
+    public fun <E> httpFailure(code: Int, error: E? = null): HttpFailure<E> {
+      checkHttpFailureCode(code)
+      return HttpFailure(code, error)
     }
 
     /** Returns a new [ApiFailure] with given [error]. */
@@ -122,6 +126,16 @@ public sealed class ApiResult<out T, out E> {
 
     /** Returns a new [UnknownFailure] with given [error]. */
     public fun unknownFailure(error: Throwable): UnknownFailure = UnknownFailure(error)
+
+    internal fun checkHttpFailureCode(code: Int) {
+      require(code !in HTTP_SUCCESS_RANGE) {
+        "Status code '$code' is a successful HTTP response. If you mean to use a $OK code + error " +
+          "string to indicate an API error, use the ApiResult.apiFailure() factory."
+      }
+      require(code in HTTP_FAILURE_RANGE) {
+        "Status code '$code' is not a HTTP failure response. Must be a 4xx code."
+      }
+    }
   }
 }
 
@@ -138,7 +152,7 @@ public object ApiResultConverterFactory : Converter.Factory() {
   override fun responseBodyConverter(
     type: Type,
     annotations: Array<out Annotation>,
-    retrofit: Retrofit
+    retrofit: Retrofit,
   ): Converter<ResponseBody, *>? {
     if (getRawType(type) != ApiResult::class.java) return null
 
@@ -161,40 +175,47 @@ public object ApiResultConverterFactory : Converter.Factory() {
   }
 
   private class ApiResultConverter(
-    private val delegate: Converter<ResponseBody, Any>
+    private val delegate: Converter<ResponseBody, Any>,
   ) : Converter<ResponseBody, ApiResult<*, *>> {
     override fun convert(value: ResponseBody): ApiResult<*, *>? {
-      return delegate.convert(value)?.let { result ->
-        ApiResult.Success(result)
-      }
+      return delegate.convert(value)?.let(::Success)
     }
   }
 }
 
 /**
- * A custom [CallAdapter.Factory] for [ApiResult] calls. This creates a delegating adapter for suspend function calls
- * that return [ApiResult]. This facilitates returning all error types through the possible [ApiResult] subtypes.
+ * A custom [CallAdapter.Factory] for [ApiResult] calls. This creates a delegating adapter for
+ * suspend function calls that return [ApiResult]. This facilitates returning all error types
+ * through the possible [ApiResult] subtypes.
  */
 public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
   @Suppress("ReturnCount")
   override fun get(
     returnType: Type,
     annotations: Array<out Annotation>,
-    retrofit: Retrofit
+    retrofit: Retrofit,
   ): CallAdapter<*, *>? {
     if (getRawType(returnType) != Call::class.java) {
       return null
     }
-    val upperBound = getParameterUpperBound(0, returnType as ParameterizedType)
-    if (getRawType(upperBound) != ApiResult::class.java) {
+    val apiResultType = getParameterUpperBound(0, returnType as ParameterizedType)
+    if (apiResultType !is ParameterizedType || apiResultType.rawType != ApiResult::class.java) {
       return null
     }
 
-    return ApiResultCallAdapter(upperBound)
+    val decodeErrorBody = annotations.any { it is DecodeErrorBody }
+    return ApiResultCallAdapter(retrofit,
+      apiResultType,
+      decodeErrorBody,
+      annotations
+    )
   }
 
   private class ApiResultCallAdapter(
-    private val responseType: Type
+    private val retrofit: Retrofit,
+    private val apiResultType: ParameterizedType,
+    private val decodeErrorBody: Boolean,
+    private val annotations: Array<out Annotation>,
   ) : CallAdapter<ApiResult<*, *>, Call<ApiResult<*, *>>> {
     override fun adapt(call: Call<ApiResult<*, *>>): Call<ApiResult<*, *>> {
       return object : Call<ApiResult<*, *>> by call {
@@ -215,11 +236,35 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
                 }
               }
 
-              override fun onResponse(call: Call<ApiResult<*, *>>, response: Response<ApiResult<*, *>>) {
+              override fun onResponse(
+                call: Call<ApiResult<*, *>>,
+                response: Response<ApiResult<*, *>>,
+              ) {
                 if (response.isSuccessful) {
                   callback.onResponse(call, response)
                 } else {
-                  callback.onResponse(call, Response.success(ApiResult.httpFailure(response.code())))
+                  var errorBody: Any? = null
+                  if (decodeErrorBody) {
+                    response.errorBody()?.let { responseBody ->
+                      // Don't try to decode empty bodies
+                      // Unknown length bodies (i.e. -1L) are fine
+                      if (responseBody.contentLength() == 0L) return@let
+                      val errorType = apiResultType.actualTypeArguments[1]
+                      val statusCode = createStatusCode(response.code())
+                      val nextAnnotations = arrayOfNulls<Annotation>(annotations.size + 1)
+                      nextAnnotations[0] = statusCode
+                      annotations.copyInto(nextAnnotations, 1)
+                      errorBody = try {
+                        retrofit.responseBodyConverter<Any>(errorType, nextAnnotations)
+                          .convert(responseBody)
+                      } catch (e: Throwable) {
+                        callback.onResponse(call, Response.success(ApiResult.unknownFailure(e)))
+                        return
+                      }
+                    }
+                  }
+                  callback.onResponse(call,
+                    Response.success(ApiResult.httpFailure(response.code(), errorBody)))
                 }
               }
             }
@@ -228,6 +273,6 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
       }
     }
 
-    override fun responseType(): Type = responseType
+    override fun responseType(): Type = apiResultType
   }
 }

--- a/src/main/java/com/slack/eithernet/ApiResult.kt
+++ b/src/main/java/com/slack/eithernet/ApiResult.kt
@@ -85,7 +85,7 @@ public sealed class ApiResult<out T, out E> {
     ) : Failure<Nothing>()
 
     /**
-     * An HTTP failure. This indicates a 4xx response. The [code] is available for reference.
+     * An HTTP failure. This indicates a 4xx or 5xx response. The [code] is available for reference.
      *
      * @property code The HTTP status code.
      * @property error An optional [error][E]. This would be from the error body of the response.
@@ -110,7 +110,7 @@ public sealed class ApiResult<out T, out E> {
   public companion object {
     private const val OK = 200
     private val HTTP_SUCCESS_RANGE = OK..299
-    private val HTTP_FAILURE_RANGE = 400..499
+    private val HTTP_FAILURE_RANGE = 400..599
 
     /** Returns a new [HttpFailure] with given [code] and optional [error]. */
     public fun <E> httpFailure(code: Int, error: E? = null): HttpFailure<E> {
@@ -133,7 +133,7 @@ public sealed class ApiResult<out T, out E> {
           "string to indicate an API error, use the ApiResult.apiFailure() factory."
       }
       require(code in HTTP_FAILURE_RANGE) {
-        "Status code '$code' is not a HTTP failure response. Must be a 4xx code."
+        "Status code '$code' is not a HTTP failure response. Must be a 4xx or 5xx code."
       }
     }
   }

--- a/src/main/java/com/slack/eithernet/DecodeErrorBody.kt
+++ b/src/main/java/com/slack/eithernet/DecodeErrorBody.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020 Slack Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.slack.eithernet
 
 import kotlin.annotation.AnnotationRetention.RUNTIME

--- a/src/main/java/com/slack/eithernet/DecodeErrorBody.kt
+++ b/src/main/java/com/slack/eithernet/DecodeErrorBody.kt
@@ -19,7 +19,8 @@ import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.FUNCTION
 
 /**
- * Indicates that this endpoint should attempt to decode 4xx response error bodies if present.
+ * Indicates that this endpoint should attempt to decode 4xx or 5xx response error bodies if
+ * present.
  *
  * This API should be considered read-only.
  */

--- a/src/main/java/com/slack/eithernet/DecodeErrorBody.kt
+++ b/src/main/java/com/slack/eithernet/DecodeErrorBody.kt
@@ -1,0 +1,13 @@
+package com.slack.eithernet
+
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.FUNCTION
+
+/**
+ * Indicates that this endpoint should attempt to decode 4xx response error bodies if present.
+ *
+ * This API should be considered read-only.
+ */
+@Target(FUNCTION)
+@Retention(RUNTIME)
+public annotation class DecodeErrorBody

--- a/src/main/java/com/slack/eithernet/ResultType.kt
+++ b/src/main/java/com/slack/eithernet/ResultType.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.KClass
 
 /**
  * Represents a [java.lang.reflect.Type] via its components. Retrieve it from Retrofit annotations
- * via [nextAnnotations] and piece this back into a real instance via [toType].
+ * via [errorType] and piece this back into a real instance via [toType].
  *
  * This API should be considered read-only.
  */

--- a/src/main/java/com/slack/eithernet/ResultTypeImpl.java
+++ b/src/main/java/com/slack/eithernet/ResultTypeImpl.java
@@ -61,7 +61,7 @@ final class ResultTypeImpl implements ResultType {
   }
 
   @Override public String toString() {
-    return "ResultTypeImpl{"
+    return "ResultType{"
         + "ownerType="
         + ownerType
         + ", rawType="

--- a/src/main/java/com/slack/eithernet/StatusCode.kt
+++ b/src/main/java/com/slack/eithernet/StatusCode.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020 Slack Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.slack.eithernet
 
 import kotlin.annotation.AnnotationRetention.RUNTIME

--- a/src/main/java/com/slack/eithernet/StatusCode.kt
+++ b/src/main/java/com/slack/eithernet/StatusCode.kt
@@ -18,7 +18,7 @@ package com.slack.eithernet
 import kotlin.annotation.AnnotationRetention.RUNTIME
 
 /**
- * Represents a status code in a 4xx response. Retrieve it from Retrofit annotations
+ * Represents a status code in a 4xx or 5xx response. Retrieve it from Retrofit annotations
  * via [statusCode].
  *
  * This API should be considered read-only.

--- a/src/main/java/com/slack/eithernet/StatusCode.kt
+++ b/src/main/java/com/slack/eithernet/StatusCode.kt
@@ -1,0 +1,12 @@
+package com.slack.eithernet
+
+import kotlin.annotation.AnnotationRetention.RUNTIME
+
+/**
+ * Represents a status code in a 4xx response. Retrieve it from Retrofit annotations
+ * via [statusCode].
+ *
+ * This API should be considered read-only.
+ */
+@Retention(RUNTIME)
+public annotation class StatusCode(public val value: Int)

--- a/src/main/java/com/slack/eithernet/StatusCodeImpl.java
+++ b/src/main/java/com/slack/eithernet/StatusCodeImpl.java
@@ -1,0 +1,36 @@
+package com.slack.eithernet;
+
+import java.lang.annotation.Annotation;
+import java.util.Objects;
+
+class StatusCodeImpl implements StatusCode {
+
+  private final int value;
+
+  StatusCodeImpl(int value) {
+    this.value = value;
+  }
+
+  @Override public int value() {
+    return value;
+  }
+
+  @Override public Class<? extends Annotation> annotationType() {
+    return StatusCode.class;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    StatusCodeImpl that = (StatusCodeImpl) o;
+    return value == that.value;
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(value);
+  }
+
+  @Override public String toString() {
+    return "StatusCode{" + "value=" + value + '}';
+  }
+}

--- a/src/test/kotlin/com/slack/eithernet/ApiResultTest.kt
+++ b/src/test/kotlin/com/slack/eithernet/ApiResultTest.kt
@@ -24,6 +24,7 @@ import okhttp3.ResponseBody
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -211,6 +212,39 @@ class ApiResultTest {
     assertThat(result).isInstanceOf(UnknownFailure::class.java)
     assertThat((result as UnknownFailure).error)
       .isInstanceOf(BadEndpointException::class.java)
+  }
+
+  @Test
+  fun statusCodeTests() {
+    // Basic value checks
+    val fourHundred = createStatusCode(400)
+    assertThat(fourHundred.value).isEqualTo(400)
+    val fiveHundred = createStatusCode(500)
+    assertThat(fiveHundred.value).isEqualTo(500)
+
+    // Basic equality checks
+    assertThat(fourHundred).isEqualTo(createStatusCode(400))
+    assertThat(fourHundred).isNotEqualTo(fiveHundred)
+  }
+
+  @Test
+  fun statusCode_200() {
+    try {
+      createStatusCode(200)
+      fail()
+    } catch (e: IllegalArgumentException) {
+      assertThat(e).hasMessageThat().contains("use the ApiResult.apiFailure()")
+    }
+  }
+
+  @Test
+  fun statusCode_non_error() {
+    try {
+      createStatusCode(307)
+      fail()
+    } catch (e: IllegalArgumentException) {
+      assertThat(e).hasMessageThat().contains("Must be a 4xx or 5xx code")
+    }
   }
 
   interface TestApi {

--- a/src/test/kotlin/com/slack/eithernet/ApiResultTest.kt
+++ b/src/test/kotlin/com/slack/eithernet/ApiResultTest.kt
@@ -95,11 +95,20 @@ class ApiResultTest {
   fun apiHttpFailure() {
     val response = MockResponse()
       .setResponseCode(404)
-      .setBody("Errors?")
 
     server.enqueue(response)
     val result = runBlocking { service.testEndpoint() }
     assertThat(result).isEqualTo(ApiResult.httpFailure(404, null))
+  }
+
+  @Test
+  fun apiHttpFailure_5xx() {
+    val response = MockResponse()
+      .setResponseCode(500)
+
+    server.enqueue(response)
+    val result = runBlocking { service.testEndpoint() }
+    assertThat(result).isEqualTo(ApiResult.httpFailure(500, null))
   }
 
   @Test

--- a/src/test/kotlin/com/slack/eithernet/ResultTypeTest.kt
+++ b/src/test/kotlin/com/slack/eithernet/ResultTypeTest.kt
@@ -62,15 +62,27 @@ class ResultTypeTest {
   }
 
   @Test
-  fun nextAnnotations() {
+  fun errorType() {
     val annotations = Array<Annotation>(4) {
       ResultTypeTest::class.java.getAnnotation(SampleAnnotation::class.java)
     }
     val resultTypeAnnotation = createResultType(String::class.java)
     annotations[0] = resultTypeAnnotation
-    val (resultType, nextAnnotations) = annotations.nextAnnotations() ?: error("No annotation found")
+    val (resultType, nextAnnotations) = annotations.errorType() ?: error("No annotation found")
     assertThat(nextAnnotations.size).isEqualTo(3)
     assertThat(resultType).isSameInstanceAs(resultTypeAnnotation)
+  }
+
+  @Test
+  fun statusCode() {
+    val annotations = Array<Annotation>(4) {
+      ResultTypeTest::class.java.getAnnotation(SampleAnnotation::class.java)
+    }
+    val statusCodeAnnotation = createStatusCode(404)
+    annotations[0] = statusCodeAnnotation
+    val (statusCode, nextAnnotations) = annotations.statusCode() ?: error("No annotation found")
+    assertThat(nextAnnotations.size).isEqualTo(3)
+    assertThat(statusCode).isSameInstanceAs(statusCodeAnnotation)
   }
 
   private class A


### PR DESCRIPTION
Resolves #6

This adds support for converting error bodies.

Changes:
* `HttpFailure` now uses the same error generic
* Endpoints can be opted in to parsing error bodies via `@DecodeErrorBody`. Zero-length bodies will be skipped
* A `@StatusCode` annotation is passed along to the converter for contextual decoding as needed per status code. We may also want to offer the headers here some day, but will save that for when someone asks for it.