### PR TITLE
Added utility function to create a successful ApiResult

### DIFF
--- a/src/main/java/com/slack/eithernet/ApiResult.kt
+++ b/src/main/java/com/slack/eithernet/ApiResult.kt
@@ -16,10 +16,18 @@
 package com.slack.eithernet
 
 import com.slack.eithernet.ApiResult.Failure
-import com.slack.eithernet.ApiResult.Failure.*
+import com.slack.eithernet.ApiResult.Failure.ApiFailure
+import com.slack.eithernet.ApiResult.Failure.HttpFailure
+import com.slack.eithernet.ApiResult.Failure.NetworkFailure
+import com.slack.eithernet.ApiResult.Failure.UnknownFailure
 import com.slack.eithernet.ApiResult.Success
 import okhttp3.ResponseBody
-import retrofit2.*
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Callback
+import retrofit2.Converter
+import retrofit2.Response
+import retrofit2.Retrofit
 import java.io.IOException
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type

--- a/src/main/java/com/slack/eithernet/ApiResult.kt
+++ b/src/main/java/com/slack/eithernet/ApiResult.kt
@@ -59,7 +59,15 @@ import java.lang.reflect.Type
 public sealed class ApiResult<out T, out E> {
 
   /** A successful result with the data available in [response]. */
-  public data class Success<T : Any>(public val response: T) : ApiResult<T, Nothing>()
+
+  public data class Success<T : Any>
+  @Deprecated(
+    message = "Use ApiResult.success(value)",
+    replaceWith = ReplaceWith(
+      expression = "ApiResult.success(response)",
+      imports = ["com.slack.eithernet.ApiResult"]
+    )
+  ) constructor(public val response: T) : ApiResult<T, Nothing>()
 
   /** Represents a failure of some sort. */
   public sealed class Failure<out E> : ApiResult<Nothing, E>() {
@@ -113,7 +121,8 @@ public sealed class ApiResult<out T, out E> {
     private val HTTP_FAILURE_RANGE = 400..599
 
     /** Returns a new [Success] with given [value]. */
-    public fun <T : Any, E> success(value: T): ApiResult<T, E> = Success(value)
+    @Suppress("DEPRECATION")
+    public fun <T : Any> success(value: T): Success<T> = Success(value)
 
     /** Returns a new [HttpFailure] with given [code] and optional [error]. */
     public fun <E> httpFailure(code: Int, error: E? = null): HttpFailure<E> {
@@ -181,7 +190,7 @@ public object ApiResultConverterFactory : Converter.Factory() {
     private val delegate: Converter<ResponseBody, Any>,
   ) : Converter<ResponseBody, ApiResult<*, *>> {
     override fun convert(value: ResponseBody): ApiResult<*, *>? {
-      return delegate.convert(value)?.let(::Success)
+      return delegate.convert(value)?.let { ApiResult.success(it) }
     }
   }
 }

--- a/src/main/java/com/slack/eithernet/ApiResult.kt
+++ b/src/main/java/com/slack/eithernet/ApiResult.kt
@@ -16,18 +16,10 @@
 package com.slack.eithernet
 
 import com.slack.eithernet.ApiResult.Failure
-import com.slack.eithernet.ApiResult.Failure.ApiFailure
-import com.slack.eithernet.ApiResult.Failure.HttpFailure
-import com.slack.eithernet.ApiResult.Failure.NetworkFailure
-import com.slack.eithernet.ApiResult.Failure.UnknownFailure
+import com.slack.eithernet.ApiResult.Failure.*
 import com.slack.eithernet.ApiResult.Success
 import okhttp3.ResponseBody
-import retrofit2.Call
-import retrofit2.CallAdapter
-import retrofit2.Callback
-import retrofit2.Converter
-import retrofit2.Response
-import retrofit2.Retrofit
+import retrofit2.*
 import java.io.IOException
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
@@ -111,6 +103,9 @@ public sealed class ApiResult<out T, out E> {
     private const val OK = 200
     private val HTTP_SUCCESS_RANGE = OK..299
     private val HTTP_FAILURE_RANGE = 400..599
+
+    /** Returns a new [Success] with given [value]. */
+    public fun <T : Any, E> success(value: T): ApiResult<T, E> = Success(value)
 
     /** Returns a new [HttpFailure] with given [code] and optional [error]. */
     public fun <E> httpFailure(code: Int, error: E? = null): HttpFailure<E> {

--- a/src/test/kotlin/com/slack/eithernet/ApiResultTest.kt
+++ b/src/test/kotlin/com/slack/eithernet/ApiResultTest.kt
@@ -67,7 +67,7 @@ class ApiResultTest {
 
     server.enqueue(response)
     val result = runBlocking { service.testEndpoint() }
-    assertThat(result).isEqualTo(ApiResult.Success("Response!"))
+    assertThat(result).isEqualTo(ApiResult.success("Response!"))
   }
 
   @Test
@@ -78,7 +78,7 @@ class ApiResultTest {
 
     server.enqueue(response)
     val result = runBlocking { service.unitEndpoint() }
-    assertThat(result).isEqualTo(ApiResult.Success(Unit))
+    assertThat(result).isEqualTo(ApiResult.success(Unit))
   }
 
   @Test


### PR DESCRIPTION
###  Summary

You can create an `ApiResult` with the syntax `ApiResult.httpFailure(error)`, but there is no utility function to create an `ApiResult` from a success value, this PR adds this utility function.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/eithernet/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).