### PR TITLE
Add tags API and tighten up general API

### DIFF
--- a/api/EitherNet.api
+++ b/api/EitherNet.api
@@ -11,71 +11,61 @@ public final class com/slack/eithernet/ApiException : java/lang/Exception {
 
 public abstract interface class com/slack/eithernet/ApiResult {
 	public static final field Companion Lcom/slack/eithernet/ApiResult$Companion;
+	public abstract fun getTags ()Ljava/util/Map;
 }
 
 public final class com/slack/eithernet/ApiResult$Companion {
+	public final fun apiFailure ()Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;
 	public final fun apiFailure (Ljava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;
-	public static synthetic fun apiFailure$default (Lcom/slack/eithernet/ApiResult$Companion;Ljava/lang/Object;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;
+	public final fun apiFailure (Ljava/lang/Object;Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;
+	public static synthetic fun apiFailure$default (Lcom/slack/eithernet/ApiResult$Companion;Ljava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;
+	public final fun httpFailure (I)Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;
 	public final fun httpFailure (ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;
-	public static synthetic fun httpFailure$default (Lcom/slack/eithernet/ApiResult$Companion;ILjava/lang/Object;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;
-	public final fun networkFailure (Ljava/io/IOException;)Lcom/slack/eithernet/ApiResult$Failure$NetworkFailure;
+	public final fun httpFailure (ILjava/lang/Object;Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;
+	public static synthetic fun httpFailure$default (Lcom/slack/eithernet/ApiResult$Companion;ILjava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;
+	public final fun networkFailure (Ljava/io/IOException;Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$NetworkFailure;
+	public static synthetic fun networkFailure$default (Lcom/slack/eithernet/ApiResult$Companion;Ljava/io/IOException;Ljava/util/Map;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$NetworkFailure;
 	public final fun success (Ljava/lang/Object;)Lcom/slack/eithernet/ApiResult$Success;
+	public final fun success (Ljava/lang/Object;Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Success;
+	public static synthetic fun success$default (Lcom/slack/eithernet/ApiResult$Companion;Ljava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Success;
 	public final fun unknownFailure (Ljava/lang/Throwable;)Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;
+	public final fun unknownFailure (Ljava/lang/Throwable;Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;
+	public static synthetic fun unknownFailure$default (Lcom/slack/eithernet/ApiResult$Companion;Ljava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;
 }
 
 public abstract interface class com/slack/eithernet/ApiResult$Failure : com/slack/eithernet/ApiResult {
 }
 
 public final class com/slack/eithernet/ApiResult$Failure$ApiFailure : com/slack/eithernet/ApiResult$Failure {
-	public final fun component1 ()Ljava/lang/Object;
-	public final fun copy (Ljava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;
-	public static synthetic fun copy$default (Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;Ljava/lang/Object;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Ljava/lang/Object;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+	public fun getTags ()Ljava/util/Map;
+	public final fun withTags (Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;
 }
 
 public final class com/slack/eithernet/ApiResult$Failure$HttpFailure : com/slack/eithernet/ApiResult$Failure {
-	public final fun component1 ()I
-	public final fun component2 ()Ljava/lang/Object;
-	public final fun copy (ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;
-	public static synthetic fun copy$default (Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;ILjava/lang/Object;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCode ()I
 	public final fun getError ()Ljava/lang/Object;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+	public fun getTags ()Ljava/util/Map;
+	public final fun withTags (Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;
 }
 
 public final class com/slack/eithernet/ApiResult$Failure$NetworkFailure : com/slack/eithernet/ApiResult$Failure {
-	public final fun component1 ()Ljava/io/IOException;
-	public final fun copy (Ljava/io/IOException;)Lcom/slack/eithernet/ApiResult$Failure$NetworkFailure;
-	public static synthetic fun copy$default (Lcom/slack/eithernet/ApiResult$Failure$NetworkFailure;Ljava/io/IOException;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$NetworkFailure;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Ljava/io/IOException;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+	public fun getTags ()Ljava/util/Map;
+	public final fun withTags (Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$NetworkFailure;
 }
 
 public final class com/slack/eithernet/ApiResult$Failure$UnknownFailure : com/slack/eithernet/ApiResult$Failure {
-	public final fun component1 ()Ljava/lang/Throwable;
-	public final fun copy (Ljava/lang/Throwable;)Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;
-	public static synthetic fun copy$default (Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Ljava/lang/Throwable;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+	public fun getTags ()Ljava/util/Map;
+	public final fun withTags (Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;
 }
 
 public final class com/slack/eithernet/ApiResult$Success : com/slack/eithernet/ApiResult {
-	public final fun component1 ()Ljava/lang/Object;
-	public final fun copy (Ljava/lang/Object;)Lcom/slack/eithernet/ApiResult$Success;
-	public static synthetic fun copy$default (Lcom/slack/eithernet/ApiResult$Success;Ljava/lang/Object;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Success;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getResponse ()Ljava/lang/Object;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+	public fun getTags ()Ljava/util/Map;
+	public final fun getValue ()Ljava/lang/Object;
+	public final fun withTags (Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Success;
 }
 
 public final class com/slack/eithernet/ApiResultCallAdapterFactory : retrofit2/CallAdapter$Factory {
@@ -102,13 +92,14 @@ public abstract interface annotation class com/slack/eithernet/StatusCode : java
 	public abstract fun value ()I
 }
 
-public final class com/slack/eithernet/Types {
-	public static fun arrayOf (Ljava/lang/reflect/Type;)Ljava/lang/reflect/GenericArrayType;
-	public static fun equals (Ljava/lang/reflect/Type;Ljava/lang/reflect/Type;)Z
-	public static fun getRawType (Ljava/lang/reflect/Type;)Ljava/lang/Class;
-	public static fun newParameterizedType (Ljava/lang/reflect/Type;[Ljava/lang/reflect/Type;)Ljava/lang/reflect/ParameterizedType;
-	public static fun newParameterizedTypeWithOwner (Ljava/lang/reflect/Type;Ljava/lang/reflect/Type;[Ljava/lang/reflect/Type;)Ljava/lang/reflect/ParameterizedType;
-	public static fun subtypeOf (Ljava/lang/reflect/Type;)Ljava/lang/reflect/WildcardType;
-	public static fun supertypeOf (Ljava/lang/reflect/Type;)Ljava/lang/reflect/WildcardType;
+public final class com/slack/eithernet/TagsKt {
+	public static final fun request (Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;)Lokhttp3/Request;
+	public static final fun request (Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;)Lokhttp3/Request;
+	public static final fun request (Lcom/slack/eithernet/ApiResult$Failure$NetworkFailure;)Lokhttp3/Request;
+	public static final fun request (Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;)Lokhttp3/Request;
+	public static final fun request (Lcom/slack/eithernet/ApiResult$Success;)Lokhttp3/Request;
+	public static final fun response (Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;)Lretrofit2/Response;
+	public static final fun response (Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;)Lretrofit2/Response;
+	public static final fun response (Lcom/slack/eithernet/ApiResult$Success;)Lretrofit2/Response;
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,9 +9,6 @@ org.gradle.configureondemand=false
 # https://kotlinlang.org/docs/reference/kapt.html#compile-avoidance-for-kapt-since-1320
 kapt.include.compile.classpath=false
 
-# Run multiple Kotlin compilations in parallel within the same project.
-kotlin.parallel.tasks.in.project=true
-
 # Add opens for Kapt
 # https://youtrack.jetbrains.com/issue/KT-45545#focus=Comments-27-4862682.0-0
 # Adds exports for GJF in spotless

--- a/src/main/java/com/slack/eithernet/ApiResult.kt
+++ b/src/main/java/com/slack/eithernet/ApiResult.kt
@@ -281,6 +281,7 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
   ) : CallAdapter<ApiResult<*, *>, Call<ApiResult<*, *>>> {
     override fun adapt(call: Call<ApiResult<*, *>>): Call<ApiResult<*, *>> {
       return object : Call<ApiResult<*, *>> by call {
+        @Suppress("LongMethod")
         override fun enqueue(callback: Callback<ApiResult<*, *>>) {
           call.enqueue(
             object : Callback<ApiResult<*, *>> {

--- a/src/main/java/com/slack/eithernet/Tags.kt
+++ b/src/main/java/com/slack/eithernet/Tags.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("UNCHECKED_CAST")
+package com.slack.eithernet
+
+import okhttp3.Request
+import retrofit2.Response
+
+/*
+ * Common tags added automatically to different ApiResult types.
+ */
+
+public fun <T : Any> ApiResult.Success<T>.response(): Response<ApiResult<T, Nothing>>? {
+  return tags[Response::class] as? Response<ApiResult<T, Nothing>>
+}
+
+public fun <T : Any> ApiResult.Success<T>.request(): Request? {
+  return tags[Request::class] as? Request
+}
+
+public fun <E : Any> ApiResult.Failure.HttpFailure<E>.response(): Response<ApiResult<Nothing, E>>? {
+  return tags[Response::class] as? Response<ApiResult<Nothing, E>>
+}
+
+public fun <E : Any> ApiResult.Failure.HttpFailure<E>.request(): Request? {
+  return tags[Request::class] as? Request
+}
+
+public fun ApiResult.Failure.UnknownFailure.response(): Response<ApiResult<Nothing, Nothing>>? {
+  return tags[Response::class] as? Response<ApiResult<Nothing, Nothing>>
+}
+
+public fun ApiResult.Failure.UnknownFailure.request(): Request? {
+  return tags[Request::class] as? Request
+}
+
+public fun <E : Any> ApiResult.Failure.ApiFailure<E>.request(): Request? {
+  return tags[Request::class] as? Request
+}
+
+public fun ApiResult.Failure.NetworkFailure.request(): Request? {
+  return tags[Request::class] as? Request
+}

--- a/src/main/java/com/slack/eithernet/Types.java
+++ b/src/main/java/com/slack/eithernet/Types.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
 import static com.slack.eithernet.Util.EMPTY_TYPE_ARRAY;
 
 /** Factory methods for types. */
-public final class Types {
+final class Types {
   private Types() {}
 
   /**


### PR DESCRIPTION
This introduces tags to plumb metadata in these types that can be useful for reading extra information about the underlying request/response. This also strips the data modifiers off the sealed subtypes because they are ultimately unhelpful due to the unstable nature of the underlying types (exceptions, now tags, etc). This matches OkHttp's own tags API in requests.