### PR TITLE
Add proguard rule to keep ApiResult

### DIFF
--- a/src/main/resources/META-INF/proguard/eithernet.pro
+++ b/src/main/resources/META-INF/proguard/eithernet.pro
@@ -1,2 +1,2 @@
-# Keep ApiResult
+# Keep ApiResult's generics or else R8 could strip them. We introspect these at runtime
 -keep,allowobfuscation,allowshrinking class com.slack.eithernet.ApiResult

--- a/src/main/resources/META-INF/proguard/eithernet.pro
+++ b/src/main/resources/META-INF/proguard/eithernet.pro
@@ -1,0 +1,2 @@
+# Keep ApiResult
+-keep,allowobfuscation,allowshrinking class com.slack.eithernet.ApiResult


### PR DESCRIPTION
###  Summary
Add proguard rule to keep `ApiResult`. Fixes #26.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/eithernet/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).