### PR TITLE
Simplify tags around plain OkHttp request/response rather than mixing + clean up API

### DIFF
--- a/api/EitherNet.api
+++ b/api/EitherNet.api
@@ -9,36 +9,29 @@ public final class com/slack/eithernet/ApiException : java/lang/Exception {
 	public final fun getError ()Ljava/lang/Object;
 }
 
-public abstract interface class com/slack/eithernet/ApiResult {
+public abstract class com/slack/eithernet/ApiResult {
 	public static final field Companion Lcom/slack/eithernet/ApiResult$Companion;
-	public abstract fun getTags ()Ljava/util/Map;
 }
 
 public final class com/slack/eithernet/ApiResult$Companion {
 	public final fun apiFailure ()Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;
 	public final fun apiFailure (Ljava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;
-	public final fun apiFailure (Ljava/lang/Object;Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;
-	public static synthetic fun apiFailure$default (Lcom/slack/eithernet/ApiResult$Companion;Ljava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;
+	public static synthetic fun apiFailure$default (Lcom/slack/eithernet/ApiResult$Companion;Ljava/lang/Object;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;
 	public final fun httpFailure (I)Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;
 	public final fun httpFailure (ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;
-	public final fun httpFailure (ILjava/lang/Object;Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;
-	public static synthetic fun httpFailure$default (Lcom/slack/eithernet/ApiResult$Companion;ILjava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;
-	public final fun networkFailure (Ljava/io/IOException;Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$NetworkFailure;
-	public static synthetic fun networkFailure$default (Lcom/slack/eithernet/ApiResult$Companion;Ljava/io/IOException;Ljava/util/Map;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$NetworkFailure;
+	public static synthetic fun httpFailure$default (Lcom/slack/eithernet/ApiResult$Companion;ILjava/lang/Object;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;
+	public final fun networkFailure (Ljava/io/IOException;)Lcom/slack/eithernet/ApiResult$Failure$NetworkFailure;
 	public final fun success (Ljava/lang/Object;)Lcom/slack/eithernet/ApiResult$Success;
-	public final fun success (Ljava/lang/Object;Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Success;
-	public static synthetic fun success$default (Lcom/slack/eithernet/ApiResult$Companion;Ljava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Success;
 	public final fun unknownFailure (Ljava/lang/Throwable;)Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;
-	public final fun unknownFailure (Ljava/lang/Throwable;Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;
-	public static synthetic fun unknownFailure$default (Lcom/slack/eithernet/ApiResult$Companion;Ljava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;
 }
 
-public abstract interface class com/slack/eithernet/ApiResult$Failure : com/slack/eithernet/ApiResult {
+public abstract class com/slack/eithernet/ApiResult$Failure : com/slack/eithernet/ApiResult {
 }
 
 public final class com/slack/eithernet/ApiResult$Failure$ApiFailure : com/slack/eithernet/ApiResult$Failure {
 	public final fun getError ()Ljava/lang/Object;
 	public fun getTags ()Ljava/util/Map;
+	public synthetic fun getTags$retrofit_api_result ()Ljava/util/Map;
 	public final fun withTags (Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;
 }
 
@@ -46,24 +39,28 @@ public final class com/slack/eithernet/ApiResult$Failure$HttpFailure : com/slack
 	public final fun getCode ()I
 	public final fun getError ()Ljava/lang/Object;
 	public fun getTags ()Ljava/util/Map;
+	public synthetic fun getTags$retrofit_api_result ()Ljava/util/Map;
 	public final fun withTags (Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;
 }
 
 public final class com/slack/eithernet/ApiResult$Failure$NetworkFailure : com/slack/eithernet/ApiResult$Failure {
 	public final fun getError ()Ljava/io/IOException;
 	public fun getTags ()Ljava/util/Map;
+	public synthetic fun getTags$retrofit_api_result ()Ljava/util/Map;
 	public final fun withTags (Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$NetworkFailure;
 }
 
 public final class com/slack/eithernet/ApiResult$Failure$UnknownFailure : com/slack/eithernet/ApiResult$Failure {
 	public final fun getError ()Ljava/lang/Throwable;
 	public fun getTags ()Ljava/util/Map;
+	public synthetic fun getTags$retrofit_api_result ()Ljava/util/Map;
 	public final fun withTags (Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;
 }
 
 public final class com/slack/eithernet/ApiResult$Success : com/slack/eithernet/ApiResult {
 	public final fun getResponse ()Ljava/lang/Object;
 	public fun getTags ()Ljava/util/Map;
+	public synthetic fun getTags$retrofit_api_result ()Ljava/util/Map;
 	public final fun getValue ()Ljava/lang/Object;
 	public final fun withTags (Ljava/util/Map;)Lcom/slack/eithernet/ApiResult$Success;
 }
@@ -93,13 +90,8 @@ public abstract interface annotation class com/slack/eithernet/StatusCode : java
 }
 
 public final class com/slack/eithernet/TagsKt {
-	public static final fun request (Lcom/slack/eithernet/ApiResult$Failure$ApiFailure;)Lokhttp3/Request;
-	public static final fun request (Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;)Lokhttp3/Request;
-	public static final fun request (Lcom/slack/eithernet/ApiResult$Failure$NetworkFailure;)Lokhttp3/Request;
-	public static final fun request (Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;)Lokhttp3/Request;
-	public static final fun request (Lcom/slack/eithernet/ApiResult$Success;)Lokhttp3/Request;
-	public static final fun response (Lcom/slack/eithernet/ApiResult$Failure$HttpFailure;)Lretrofit2/Response;
-	public static final fun response (Lcom/slack/eithernet/ApiResult$Failure$UnknownFailure;)Lretrofit2/Response;
-	public static final fun response (Lcom/slack/eithernet/ApiResult$Success;)Lretrofit2/Response;
+	public static final fun request (Lcom/slack/eithernet/ApiResult;)Lokhttp3/Request;
+	public static final fun response (Lcom/slack/eithernet/ApiResult;)Lokhttp3/Response;
+	public static final fun tag (Lcom/slack/eithernet/ApiResult;Lkotlin/reflect/KClass;)Ljava/lang/Object;
 }
 

--- a/src/main/java/com/slack/eithernet/ApiResult.kt
+++ b/src/main/java/com/slack/eithernet/ApiResult.kt
@@ -32,6 +32,7 @@ import retrofit2.Retrofit
 import java.io.IOException
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
+import java.util.Collections.unmodifiableMap
 import kotlin.DeprecationLevel.ERROR
 import kotlin.reflect.KClass
 
@@ -72,7 +73,7 @@ public sealed class ApiResult<out T : Any, out E : Any> {
 
     /** Returns a new copy of this with the given [tags]. */
     public fun withTags(tags: Map<KClass<*>, Any>): Success<T> {
-      return Success(value, tags)
+      return Success(value, unmodifiableMap(tags.toMap()))
     }
 
     @Deprecated("Use value. This will be removed in 1.0", ReplaceWith("value"), ERROR)
@@ -94,7 +95,7 @@ public sealed class ApiResult<out T : Any, out E : Any> {
     ) : Failure<Nothing>() {
       /** Returns a new copy of this with the given [tags]. */
       public fun withTags(tags: Map<KClass<*>, Any>): NetworkFailure {
-        return NetworkFailure(error, tags)
+        return NetworkFailure(error, unmodifiableMap(tags.toMap()))
       }
     }
 
@@ -110,7 +111,7 @@ public sealed class ApiResult<out T : Any, out E : Any> {
     ) : Failure<Nothing>() {
       /** Returns a new copy of this with the given [tags]. */
       public fun withTags(tags: Map<KClass<*>, Any>): UnknownFailure {
-        return UnknownFailure(error, tags)
+        return UnknownFailure(error, unmodifiableMap(tags.toMap()))
       }
     }
 
@@ -127,7 +128,7 @@ public sealed class ApiResult<out T : Any, out E : Any> {
     ) : Failure<E>() {
       /** Returns a new copy of this with the given [tags]. */
       public fun withTags(tags: Map<KClass<*>, Any>): HttpFailure<E> {
-        return HttpFailure(code, error, tags)
+        return HttpFailure(code, error, unmodifiableMap(tags.toMap()))
       }
     }
 
@@ -146,7 +147,7 @@ public sealed class ApiResult<out T : Any, out E : Any> {
     ) : Failure<E>() {
       /** Returns a new copy of this with the given [tags]. */
       public fun withTags(tags: Map<KClass<*>, Any>): ApiFailure<E> {
-        return ApiFailure(error, tags)
+        return ApiFailure(error, unmodifiableMap(tags.toMap()))
       }
     }
   }

--- a/src/main/java/com/slack/eithernet/ApiResult.kt
+++ b/src/main/java/com/slack/eithernet/ApiResult.kt
@@ -330,8 +330,7 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
                 if (response.isSuccessful) {
                   // Repackage the initial result with new tags with this call's request + response
                   val tags = mapOf(
-                    Request::class to call.request(),
-                    Response::class to response
+                    okhttp3.Response::class to response.raw()
                   )
                   val withTag = when (val result = response.body()) {
                     is Success -> result.withTags(result.tags + tags)
@@ -360,8 +359,7 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
                             ApiResult.unknownFailure(
                               error = e,
                               tags = mapOf(
-                                Request::class to call.request(),
-                                Response::class to response
+                                okhttp3.Response::class to response.raw()
                               )
                             )
                           )
@@ -378,8 +376,7 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
                         code = response.code(),
                         error = errorBody,
                         tags = mapOf(
-                          Request::class to call.request(),
-                          Response::class to response
+                          okhttp3.Response::class to response.raw()
                         )
                       )
                     )

--- a/src/main/java/com/slack/eithernet/ApiResult.kt
+++ b/src/main/java/com/slack/eithernet/ApiResult.kt
@@ -59,16 +59,16 @@ import kotlin.reflect.KClass
  * Usually, user code for this could just simply show a generic error message for a [Failure]
  * case, but a sealed class is exposed for more specific error messaging.
  */
-public sealed interface ApiResult<out T : Any, out E : Any> {
+public sealed class ApiResult<out T : Any, out E : Any> {
 
   /** Extra metadata associated with the result such as original requests, responses, etc. */
-  public val tags: Map<KClass<*>, Any>
+  internal abstract val tags: Map<KClass<*>, Any>
 
   /** A successful result with the data available in [response]. */
   public class Success<T : Any> internal constructor(
     public val value: T,
     public override val tags: Map<KClass<*>, Any>
-  ) : ApiResult<T, Nothing> {
+  ) : ApiResult<T, Nothing>() {
 
     /** Returns a new copy of this with the given [tags]. */
     public fun withTags(tags: Map<KClass<*>, Any>): Success<T> {
@@ -80,7 +80,7 @@ public sealed interface ApiResult<out T : Any, out E : Any> {
   }
 
   /** Represents a failure of some sort. */
-  public sealed interface Failure<E : Any> : ApiResult<Nothing, E> {
+  public sealed class Failure<E : Any> : ApiResult<Nothing, E>() {
 
     /**
      * A network failure caused by a given [error]. This error is opaque, as the actual type could
@@ -91,7 +91,7 @@ public sealed interface ApiResult<out T : Any, out E : Any> {
     public class NetworkFailure internal constructor(
       public val error: IOException,
       public override val tags: Map<KClass<*>, Any>
-    ) : Failure<Nothing> {
+    ) : Failure<Nothing>() {
       /** Returns a new copy of this with the given [tags]. */
       public fun withTags(tags: Map<KClass<*>, Any>): NetworkFailure {
         return NetworkFailure(error, tags)
@@ -107,7 +107,7 @@ public sealed interface ApiResult<out T : Any, out E : Any> {
     public class UnknownFailure internal constructor(
       public val error: Throwable,
       public override val tags: Map<KClass<*>, Any>
-    ) : Failure<Nothing> {
+    ) : Failure<Nothing>() {
       /** Returns a new copy of this with the given [tags]. */
       public fun withTags(tags: Map<KClass<*>, Any>): UnknownFailure {
         return UnknownFailure(error, tags)
@@ -124,7 +124,7 @@ public sealed interface ApiResult<out T : Any, out E : Any> {
       public val code: Int,
       public val error: E?,
       public override val tags: Map<KClass<*>, Any>
-    ) : Failure<E> {
+    ) : Failure<E>() {
       /** Returns a new copy of this with the given [tags]. */
       public fun withTags(tags: Map<KClass<*>, Any>): HttpFailure<E> {
         return HttpFailure(code, error, tags)
@@ -143,7 +143,7 @@ public sealed interface ApiResult<out T : Any, out E : Any> {
     public class ApiFailure<E : Any> internal constructor(
       public val error: E?,
       public override val tags: Map<KClass<*>, Any>
-    ) : Failure<E> {
+    ) : Failure<E>() {
       /** Returns a new copy of this with the given [tags]. */
       public fun withTags(tags: Map<KClass<*>, Any>): ApiFailure<E> {
         return ApiFailure(error, tags)

--- a/src/main/java/com/slack/eithernet/ApiResult.kt
+++ b/src/main/java/com/slack/eithernet/ApiResult.kt
@@ -158,42 +158,27 @@ public sealed class ApiResult<out T : Any, out E : Any> {
     private val HTTP_FAILURE_RANGE = 400..599
 
     /** Returns a new [Success] with given [value]. */
-    @JvmOverloads
-    public fun <T : Any> success(
-      value: T,
-      tags: Map<KClass<*>, Any> = emptyMap()
-    ): Success<T> = Success(value, tags)
+    public fun <T : Any> success(value: T): Success<T> = Success(value, emptyMap())
 
     /** Returns a new [HttpFailure] with given [code] and optional [error]. */
     @JvmOverloads
     public fun <E : Any> httpFailure(
       code: Int,
       error: E? = null,
-      tags: Map<KClass<*>, Any> = emptyMap()
     ): HttpFailure<E> {
       checkHttpFailureCode(code)
-      return HttpFailure(code, error, tags)
+      return HttpFailure(code, error, emptyMap())
     }
 
     /** Returns a new [ApiFailure] with given [error]. */
     @JvmOverloads
-    public fun <E : Any> apiFailure(
-      error: E? = null,
-      tags: Map<KClass<*>, Any> = emptyMap()
-    ): ApiFailure<E> = ApiFailure(error, tags)
+    public fun <E : Any> apiFailure(error: E? = null): ApiFailure<E> = ApiFailure(error, emptyMap())
 
     /** Returns a new [NetworkFailure] with given [error]. */
-    public fun networkFailure(
-      error: IOException,
-      tags: Map<KClass<*>, Any> = emptyMap()
-    ): NetworkFailure = NetworkFailure(error, tags)
+    public fun networkFailure(error: IOException): NetworkFailure = NetworkFailure(error, emptyMap())
 
     /** Returns a new [UnknownFailure] with given [error]. */
-    @JvmOverloads
-    public fun unknownFailure(
-      error: Throwable,
-      tags: Map<KClass<*>, Any> = emptyMap()
-    ): UnknownFailure = UnknownFailure(error, tags)
+    public fun unknownFailure(error: Throwable): UnknownFailure = UnknownFailure(error, emptyMap())
 
     internal fun checkHttpFailureCode(code: Int) {
       require(code !in HTTP_SUCCESS_RANGE) {
@@ -292,7 +277,7 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
                     callback.onResponse(
                       call,
                       Response.success(
-                        ApiResult.apiFailure(
+                        ApiFailure(
                           error = t.error,
                           tags = mapOf(Request::class to call.request())
                         )
@@ -303,7 +288,7 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
                     callback.onResponse(
                       call,
                       Response.success(
-                        ApiResult.networkFailure(
+                        NetworkFailure(
                           error = t,
                           tags = mapOf(Request::class to call.request())
                         ),
@@ -314,7 +299,7 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
                     callback.onResponse(
                       call,
                       Response.success(
-                        ApiResult.unknownFailure(
+                        UnknownFailure(
                           error = t,
                           tags = mapOf(Request::class to call.request())
                         ),
@@ -357,7 +342,7 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
                         callback.onResponse(
                           call,
                           Response.success(
-                            ApiResult.unknownFailure(
+                            UnknownFailure(
                               error = e,
                               tags = mapOf(
                                 okhttp3.Response::class to response.raw()
@@ -373,7 +358,7 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
                   callback.onResponse(
                     call,
                     Response.success(
-                      ApiResult.httpFailure(
+                      HttpFailure(
                         code = response.code(),
                         error = errorBody,
                         tags = mapOf(

--- a/src/main/java/com/slack/eithernet/Tags.kt
+++ b/src/main/java/com/slack/eithernet/Tags.kt
@@ -18,17 +18,26 @@ package com.slack.eithernet
 
 import okhttp3.Request
 import okhttp3.Response
+import kotlin.reflect.KClass
 
 /*
  * Common tags added automatically to different ApiResult types.
  */
 
+/**
+ * Returns the tag attached with [T] as a key, or null if no tag is attached with that
+ * key.
+ */
+public inline fun <reified T : Any> ApiResult<*, *>.tag(): T? = tag(T::class)
+
+/**
+ * Returns the tag attached with [klass] as a key, or null if no tag is attached with that
+ * key.
+ */
+public fun <T : Any> ApiResult<*, *>.tag(klass: KClass<T>): T? = tags[klass] as? T
+
 /** Returns the original [Response] used for this call. */
-public fun ApiResult<*, *>.response(): Response? {
-  return tags[Response::class] as? Response
-}
+public fun ApiResult<*, *>.response(): Response? = tag()
 
 /** Returns the original [Request] used for this call. */
-public fun ApiResult<*, *>.request(): Request? {
-  return response()?.request() ?: tags[Request::class] as? Request
-}
+public fun ApiResult<*, *>.request(): Request? = response()?.request() ?: tag()

--- a/src/main/java/com/slack/eithernet/Tags.kt
+++ b/src/main/java/com/slack/eithernet/Tags.kt
@@ -17,40 +17,18 @@
 package com.slack.eithernet
 
 import okhttp3.Request
-import retrofit2.Response
+import okhttp3.Response
 
 /*
  * Common tags added automatically to different ApiResult types.
  */
 
-public fun <T : Any> ApiResult.Success<T>.response(): Response<ApiResult<T, Nothing>>? {
-  return tags[Response::class] as? Response<ApiResult<T, Nothing>>
+/** Returns the original [Response] used for this call. */
+public fun ApiResult<*, *>.response(): Response? {
+  return tags[Response::class] as? Response
 }
 
-public fun <T : Any> ApiResult.Success<T>.request(): Request? {
-  return tags[Request::class] as? Request
-}
-
-public fun <E : Any> ApiResult.Failure.HttpFailure<E>.response(): Response<ApiResult<Nothing, E>>? {
-  return tags[Response::class] as? Response<ApiResult<Nothing, E>>
-}
-
-public fun <E : Any> ApiResult.Failure.HttpFailure<E>.request(): Request? {
-  return tags[Request::class] as? Request
-}
-
-public fun ApiResult.Failure.UnknownFailure.response(): Response<ApiResult<Nothing, Nothing>>? {
-  return tags[Response::class] as? Response<ApiResult<Nothing, Nothing>>
-}
-
-public fun ApiResult.Failure.UnknownFailure.request(): Request? {
-  return tags[Request::class] as? Request
-}
-
-public fun <E : Any> ApiResult.Failure.ApiFailure<E>.request(): Request? {
-  return tags[Request::class] as? Request
-}
-
-public fun ApiResult.Failure.NetworkFailure.request(): Request? {
-  return tags[Request::class] as? Request
+/** Returns the original [Request] used for this call. */
+public fun ApiResult<*, *>.request(): Request? {
+  return response()?.request() ?: tags[Request::class] as? Request
 }


### PR DESCRIPTION
This cleans up the new tags API in a few ways:

* Focuses on symmetric OkHttp `Request`/`Response`, rather than the previous asymmetric OkHttp `Request`/Retrofit `Response`
* Converts back to sealed classes and makes `tags` an `internal` property. We could keep the interfaces if we want, but would require unpacking the real classes and accessing internally that way. Open to suggestions on this.
* Remove `tags` from factory creators in favor of always having folks use the `withTags` helpers.
* Defensively copy tags and make the internal model immutable.