### PR TITLE
Upstream EitherNetControllers API as test fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,76 @@ class ErrorConverterFactory : Converter.Factory() {
 }
 ```
 
+## Testing
+
+EitherNet ships with a [Test Fixtures](https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures)
+artifact containing a `EitherNetController` API to allow for easy testing with EitherNet APIs. This
+is similar to OkHttp’s `MockWebServer`, where results can be enqueued for specific endpoints.
+
+Simply create a new controller instance in your test using one of the `newEitherNetController()` functions.
+
+```kotlin
+val controller = newEitherNetController<PandaApi>() // reified type
+```
+
+Then you can access the underlying faked `api` property from it and pass that on to whatever’s being tested.
+
+
+```kotlin
+// Take the api instance from the controller and pass it to whatever's being tested
+val provider = PandaDataProvider(controller.api)
+```
+
+Finally, enqueue results for endpoints as needed.
+
+```kotlin
+// Later in a test you can enqueue results for specific endpoints
+controller.enqueue(PandaApi::getPandas, ApiResult.success("Po"))
+```
+
+You can also optionally pass in full suspend functions if you need dynamic behavior
+
+```kotlin
+controller.enqueue(PandaApi::getPandas) {
+  // This is a suspend function!
+  delay(1000)
+  ApiResult.success("Po")
+}
+```
+
+In instrumentation tests with DI, you can provide the controller and its underlying API in a test
+module and replace the standard one. This works particularly well with [Anvil](https://github.com/square/anvil).
+
+```kotlin
+@ContributesTo(
+  scope = UserScope::class,
+  replaces = [PandaApiModule::class] // Replace the standard module
+)
+@Module
+object TestPandaApiModule {
+  @Provides
+  fun providePandaApiController(): EitherNetController<PandaApi> = newEitherNetController()
+
+  @Provides
+  fun providePandaApi(
+    controller: EitherNetController<PandaApi>
+  ): PandaApi = controller.api
+}
+```
+
+Then you can inject the controller in your test while users of `PandaApi` will get your test instance.
+
+For Java interop, there is a limited API available at `JavaEitherNetControllers.enqueueFromJava`.
+
 ## Installation
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.slack.eithernet/eithernet.svg)](https://mvnrepository.com/artifact/com.slack.eithernet/eithernet)
 ```gradle
 dependencies {
   implementation("com.slack.eithernet:eithernet:<version>")
+
+  // Test fixtures
+  testImplementation(testFixtures("com.slack.eithernet:eithernet:<version>"))
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,15 @@ object TestPandaApiModule {
 
 Then you can inject the controller in your test while users of `PandaApi` will get your test instance.
 
+### Java Interop
+
 For Java interop, there is a limited API available at `JavaEitherNetControllers.enqueueFromJava`.
+
+### Validation
+
+`EitherNetController` will run some small validation on API endpoints under the hood. If you want to
+add your own validations on top of this, you can provide implementations of `ApiValidator` via
+`ServiceLoader`. See `ApiValidator`'s docs for more information.
 
 ## Installation
 

--- a/api/EitherNet.api
+++ b/api/EitherNet.api
@@ -67,6 +67,12 @@ public final class com/slack/eithernet/ApiResultConverterFactory : retrofit2/Con
 public abstract interface annotation class com/slack/eithernet/DecodeErrorBody : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class com/slack/eithernet/ExperimentalEitherNetApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class com/slack/eithernet/InternalEitherNetApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class com/slack/eithernet/ResultType : java/lang/annotation/Annotation {
 	public abstract fun isArray ()Z
 	public abstract fun ownerType ()Ljava/lang/Class;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,12 +19,12 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URL
 
 plugins {
-  kotlin("jvm") version "1.5.21"
-  id("org.jetbrains.dokka") version "1.5.0"
-  id("com.diffplug.spotless") version "5.14.1"
-  id("com.vanniktech.maven.publish") version "0.17.0"
-  id("io.gitlab.arturbosch.detekt") version "1.17.0"
-  id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.6.0"
+  kotlin("jvm") version "1.5.30"
+  id("org.jetbrains.dokka") version "1.5.30"
+  id("com.diffplug.spotless") version "5.15.0"
+  id("com.vanniktech.maven.publish") version "0.18.0"
+  id("io.gitlab.arturbosch.detekt") version "1.18.1"
+  id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.7.1"
 }
 
 repositories {

--- a/src/main/java/com/slack/eithernet/ExperimentalEitherNetApi.kt
+++ b/src/main/java/com/slack/eithernet/ExperimentalEitherNetApi.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.eithernet
+
+import kotlin.RequiresOptIn.Level.ERROR
+import kotlin.annotation.AnnotationRetention.BINARY
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
+import kotlin.annotation.AnnotationTarget.TYPEALIAS
+
+/** Indicates that a given API is currently experimental and subject to change. */
+@Retention(BINARY)
+@Target(CLASS, FUNCTION, TYPEALIAS, PROPERTY)
+@RequiresOptIn(
+  level = ERROR,
+  message = "Indicates that a given API is currently experimental and subject to change."
+)
+public annotation class ExperimentalEitherNetApi

--- a/src/main/java/com/slack/eithernet/InternalEitherNetApi.kt
+++ b/src/main/java/com/slack/eithernet/InternalEitherNetApi.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.eithernet
+
+import kotlin.RequiresOptIn.Level.ERROR
+import kotlin.annotation.AnnotationRetention.BINARY
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
+import kotlin.annotation.AnnotationTarget.TYPEALIAS
+
+/**
+ * Marks declarations that are **internal** in EitherNet API, which means that they should not be used outside of
+ * `com.slack.eithernet`, because their signatures and semantics will change between future releases without any
+ * warnings and without providing any migration aids.
+ */
+@Retention(BINARY)
+@Target(CLASS, FUNCTION, TYPEALIAS, PROPERTY)
+@RequiresOptIn(
+  level = ERROR,
+  message = "This is an internal EitherNet API that " +
+    "should not be used from outside of EitherNet. No compatibility guarantees are provided."
+)
+public annotation class InternalEitherNetApi

--- a/src/test/kotlin/com/slack/eithernet/EitherNetControllersTest.kt
+++ b/src/test/kotlin/com/slack/eithernet/EitherNetControllersTest.kt
@@ -1,0 +1,266 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.eithernet
+
+import com.google.auto.service.AutoService
+import com.google.common.truth.Truth.assertThat
+import com.slack.eithernet.ApiResult.Failure.HttpFailure
+import com.slack.eithernet.ApiResult.Success
+import com.slack.eithernet.test.ApiValidator
+import com.slack.eithernet.test.enqueue
+import com.slack.eithernet.test.newEitherNetController
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Test
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.hasAnnotation
+import kotlin.test.assertFailsWith
+import kotlin.test.fail
+
+@ExperimentalEitherNetApi
+class EitherNetControllersTest {
+
+  @Test
+  fun happyPath() {
+    val testApi = newEitherNetController<PandaApi>()
+    val api = testApi.api
+
+    testApi.enqueue(PandaApi::getPandas) {
+      ApiResult.success("Po")
+    }
+
+    val result = runBlocking { api.getPandas() }
+    check(result is Success)
+    assertThat(result.value).isEqualTo("Po")
+  }
+
+  @Test
+  fun happyPath_scalar() {
+    val testApi = newEitherNetController<PandaApi>()
+    val api = testApi.api
+
+    testApi.enqueue(PandaApi::getPandas, ApiResult.success("Po"))
+
+    val result = runBlocking { api.getPandas() }
+    check(result is Success)
+    assertThat(result.value).isEqualTo("Po")
+  }
+
+  @Test
+  fun functionWithParams() {
+    val testApi = newEitherNetController<PandaApi>()
+    val api = testApi.api
+
+    testApi.enqueue(PandaApi::getPandasWithParams, ApiResult.success("Po"))
+
+    val result = runBlocking { api.getPandasWithParams(1) }
+    check(result is Success)
+    assertThat(result.value).isEqualTo("Po")
+  }
+
+  @Test
+  fun failure() {
+    val testApi = newEitherNetController<PandaApi>()
+    val api = testApi.api
+
+    testApi.enqueue(PandaApi::getPandas, ApiResult.httpFailure(404))
+
+    val result = runBlocking { api.getPandas() }
+    check(result is HttpFailure)
+    assertThat(result.code).isEqualTo(404)
+  }
+
+  @Test
+  fun mismatchedResultType() {
+    val testApi = newEitherNetController<PandaApi>()
+
+    try {
+      testApi.enqueue(PandaApi::getPandas, ApiResult.success(3))
+      fail()
+    } catch (e: IllegalStateException) {
+      assertThat(e).hasMessageThat().contains("Type check failed")
+    }
+  }
+
+  @Test
+  fun mismatchedApiFunctions() {
+    val testApi = newEitherNetController<PandaApi>()
+
+    try {
+      testApi.enqueue(AnotherApi::getPandas, ApiResult.success("Po"))
+      fail()
+    } catch (e: IllegalStateException) {
+      assertThat(e).hasMessageThat().contains("is not a member of target API")
+    }
+  }
+
+  @Test
+  fun invalidApi() {
+    try {
+      newEitherNetController<BadApi>()
+      fail()
+    } catch (e: IllegalStateException) {
+      assertThat(e).hasMessageThat().contains(
+        """
+        Service errors found for BadApi
+        - Function missingApiResult must return ApiResult for EitherNet to work.
+        - Function missingSlackEndpoint is missing @SlackEndpoint annotation.
+        - Function missingSuspend must be a suspend function for EitherNet to work.
+        """.trimIndent()
+      )
+    }
+  }
+
+  @Test
+  fun unstubbed_failure() {
+    val testApi = newEitherNetController<PandaApi>()
+    val api = testApi.api
+
+    testApi.enqueue(PandaApi::getPandasWithParams, ApiResult.success("Po"))
+
+    try {
+      runBlocking { api.getPandas() }
+      fail()
+    } catch (e: IllegalStateException) {
+      assertThat(e).hasMessageThat().contains("No result enqueued for getPandas.")
+    }
+  }
+
+  @Test
+  fun custom_behavior_example() {
+    val testApi = newEitherNetController<PandaApi>()
+    val api = testApi.api
+
+    testApi.enqueue(PandaApi::getPandas) {
+      // Never "returns"!
+      awaitCancellation()
+    }
+
+    assertFailsWith<TimeoutCancellationException> {
+      runBlocking {
+        withTimeout(1000) {
+          api.getPandas()
+        }
+      }
+    }
+  }
+
+  @Test
+  fun custom_behavior_example2() {
+    val testApi = newEitherNetController<PandaApi>()
+    val api = testApi.api
+    val expected = Exception()
+
+    testApi.enqueue(PandaApi::getPandas) {
+      throw expected
+    }
+
+    try {
+      runBlocking {
+        api.getPandas()
+      }
+      fail()
+    } catch (e: Exception) {
+      assertThat(e).isSameInstanceAs(expected)
+    }
+  }
+
+  @Test
+  fun assertNoMoreQueuedResults() {
+    val testApi = newEitherNetController<PandaApi>()
+    val api = testApi.api
+
+    // Enqueue a result
+    testApi.enqueue(PandaApi::getPandas, ApiResult.success("Po"))
+
+    // Asserting before taking results fails correctly
+    try {
+      testApi.assertNoMoreQueuedResults()
+      fail()
+    } catch (e: AssertionError) {
+      assertThat(e).hasMessageThat()
+        .isEqualTo(
+          """
+          Found unprocessed ApiResults:
+          -- getPandas() has 1 unprocessed result
+          """.trimIndent()
+        )
+    }
+
+    // Now process the result
+    runBlocking {
+      api.getPandas()
+    }
+
+    // Now it successfully asserts
+    testApi.assertNoMoreQueuedResults()
+  }
+
+  // Cover for inherited APIs
+  interface BaseApi {
+    @SlackEndpoint
+    suspend fun getPandas(): ApiResult<String, Unit>
+  }
+
+  interface PandaApi : BaseApi {
+    @SlackEndpoint
+    suspend fun getPandasWithParams(count: Int): ApiResult<String, Unit>
+  }
+
+  interface AnotherApi {
+    @SlackEndpoint
+    suspend fun getPandas(): ApiResult<String, Unit>
+  }
+
+  interface BadApi {
+    suspend fun missingSlackEndpoint(): ApiResult<String, Unit>
+
+    @SlackEndpoint
+    fun missingSuspend(): ApiResult<String, Unit>
+
+    @SlackEndpoint
+    suspend fun missingApiResult(): String
+
+    fun defaultMethodIsSkipped() {
+    }
+
+    @JvmSynthetic
+    fun syntheticMethodIsSkipped() {
+    }
+
+    companion object {
+      @JvmStatic
+      fun staticMethodsIsSkipped() {
+      }
+    }
+  }
+}
+
+/** Example of a marker annotation for a validator to require */
+annotation class SlackEndpoint
+
+@ExperimentalEitherNetApi
+@AutoService(ApiValidator::class)
+class SlackEndpointValidator : ApiValidator {
+  override fun validate(apiClass: KClass<*>, function: KFunction<*>, errors: MutableList<String>) {
+    if (!function.hasAnnotation<SlackEndpoint>()) {
+      errors += "- Function ${function.name} is missing @SlackEndpoint annotation."
+    }
+  }
+}

--- a/src/testFixtures/java/com/slack/eithernet/test/ApiValidation.kt
+++ b/src/testFixtures/java/com/slack/eithernet/test/ApiValidation.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.eithernet.test
+
+import com.slack.eithernet.ExperimentalEitherNetApi
+import java.util.ServiceLoader
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+
+/**
+ * A simple callback API for validating APIs in [EitherNetController]. Implementations of this can
+ * be supplied via [ServiceLoader].
+ */
+@ExperimentalEitherNetApi
+fun interface ApiValidator {
+  /**
+   * Callback to validate a given [function] from the given [apiClass].
+   *
+   * If any errors are found, add a detailed description to [errors].
+   */
+  fun validate(
+    apiClass: KClass<*>,
+    function: KFunction<*>,
+    errors: MutableList<String>
+  )
+}
+
+@OptIn(ExperimentalEitherNetApi::class)
+internal fun loadValidators(): Set<ApiValidator> = ServiceLoader.load(ApiValidator::class.java)
+  .toSet()

--- a/src/testFixtures/java/com/slack/eithernet/test/CoroutineTransformer.java
+++ b/src/testFixtures/java/com/slack/eithernet/test/CoroutineTransformer.java
@@ -1,0 +1,30 @@
+package com.slack.eithernet.test;
+
+import com.slack.eithernet.ApiResult;
+import kotlin.coroutines.Continuation;
+import kotlin.jvm.functions.Function2;
+
+enum CoroutineTransformer {
+  ;
+
+  /**
+   * A weird but effective way to redirect a {@link Continuation} acquired via reflection back into
+   * a true {@code suspend} function.
+   */
+  public static Object transform(
+      Object[] args, Object body, Continuation<? super ApiResult<?, ?>> continuation) {
+    try {
+      //noinspection unchecked
+      return UtilKt.awaitResponse(
+          (Function2<
+                  ? super Object[],
+                  ? super Continuation<? super ApiResult<?, ?>>,
+                  ? extends Object>)
+              body,
+          args,
+          continuation);
+    } catch (Exception e) {
+      return UtilKt.suspendAndThrow(e, continuation);
+    }
+  }
+}

--- a/src/testFixtures/java/com/slack/eithernet/test/EitherNetController.kt
+++ b/src/testFixtures/java/com/slack/eithernet/test/EitherNetController.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.eithernet.test
+
+import com.slack.eithernet.ApiResult
+import com.slack.eithernet.ExperimentalEitherNetApi
+import com.slack.eithernet.InternalEitherNetApi
+import kotlin.reflect.KFunction
+import kotlin.reflect.jvm.javaMethod
+
+/**
+ * This is a helper API returned by [newEitherNetController] to help with testing EitherNet endpoints.
+ *
+ * Simple usage looks something like this:
+ * ```
+ * val controller = newEitherNetController<PandaApi>()
+ *
+ * // Take the api instance from the controller!
+ * val provider = PandaDataProvider(controller.api)
+ *
+ * // Later in a test
+ * controller.enqueue(PandaApi::getPandas, ApiResult.success("Po"))
+ * ```
+ *
+ * Enqueued results are keyed to their corresponding endpoint. There is also an overload of
+ * [enqueue] that accepts a `suspend` function body to allow for custom/dynamic behavior.
+ *
+ * For Java interop, there is a limited API available at [enqueueFromJava].
+ */
+@ExperimentalEitherNetApi
+interface EitherNetController<T : Any> {
+  /** The underlying API implementation that should be passed into the thing being tested. */
+  val api: T
+
+  /** Asserts that there are no more remaining results in the queue. */
+  fun assertNoMoreQueuedResults()
+
+  @InternalEitherNetApi
+  fun <S : Any, E : Any> unsafeEnqueue(
+    key: EndpointKey,
+    resultBody: suspend (args: Array<Any>) -> ApiResult<S, E>
+  )
+}
+
+/** Enqueues a suspended [resultBody]. */
+@ExperimentalEitherNetApi
+inline fun <reified T : Any, reified S : Any, reified E : Any> EitherNetController<T>.enqueue(
+  ref: KFunction<ApiResult<S, E>>,
+  noinline resultBody: suspend (args: Array<Any>) -> ApiResult<S, E>
+) {
+  ref.validateTypes()
+  val apiClass = T::class.java
+  check(ref.javaMethod?.declaringClass?.isAssignableFrom(apiClass) == true) {
+    "Given function ${ref.javaMethod?.declaringClass}.${ref.name} is not a member of target API $apiClass."
+  }
+  val key = createEndpointKey(ref.javaMethod!!)
+  @OptIn(InternalEitherNetApi::class)
+  unsafeEnqueue(key, resultBody)
+}
+
+/** Enqueues a scalar [result] instance. */
+@ExperimentalEitherNetApi
+inline fun <reified T : Any, reified S : Any, reified E : Any> EitherNetController<T>.enqueue(
+  ref: KFunction<ApiResult<S, E>>,
+  result: ApiResult<S, E>
+) = enqueue(ref) { result }

--- a/src/testFixtures/java/com/slack/eithernet/test/EitherNetControllers.kt
+++ b/src/testFixtures/java/com/slack/eithernet/test/EitherNetControllers.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.eithernet.test
+
+import com.slack.eithernet.ApiResult
+import com.slack.eithernet.ExperimentalEitherNetApi
+import com.slack.eithernet.test.Platform.Companion
+import com.squareup.moshi.rawType
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import java.lang.reflect.Proxy
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.Continuation
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.functions
+import kotlin.reflect.javaType
+import kotlin.reflect.jvm.javaMethod
+
+/** Returns a new [EitherNetController] for API service type [T]. */
+@ExperimentalEitherNetApi
+inline fun <reified T : Any> newEitherNetController(): EitherNetController<T> {
+  return newEitherNetController(T::class)
+}
+
+/** Returns a new [EitherNetController] for API service type [T]. */
+@ExperimentalEitherNetApi
+fun <T : Any> newEitherNetController(service: Class<T>): EitherNetController<T> {
+  return newEitherNetController(service.kotlin)
+}
+
+/** Returns a new [EitherNetController] for API service type [T]. */
+@ExperimentalEitherNetApi
+fun <T : Any> newEitherNetController(service: KClass<T>): EitherNetController<T> {
+  service.validateApi()
+  // Get functions with retrofit annotations
+  val endpoints = service.functions
+    .filter { it.isApplicable }
+    .map { createEndpointKey(it.javaMethod!!) } // We know javaMethod is present per the filter
+    .associateWithTo(ConcurrentHashMap()) { ArrayDeque<SuspendedResult>() }
+  val orchestrator = EitherNetTestOrchestrator(endpoints)
+  val proxy = newProxy(service.java, orchestrator)
+  return RealEitherNetController(orchestrator, proxy)
+}
+
+private val KFunction<*>.isApplicable: Boolean
+  get() {
+    // Default, static, synthetic, and bridge methods are not applicable
+    return javaMethod?.let { method ->
+      method.declaringClass != Object::class.java &&
+        !method.isDefault &&
+        !Modifier.isStatic(method.modifiers) &&
+        !method.isSynthetic &&
+        !method.isBridge
+    } ?: false
+  }
+
+@OptIn(ExperimentalStdlibApi::class, ExperimentalEitherNetApi::class)
+private fun KClass<*>.validateApi() {
+  val validators = loadValidators()
+  val errors = mutableListOf<String>()
+  for (function in functions) {
+    if (!function.isApplicable) {
+      continue
+    }
+    if (!function.isSuspend) {
+      errors += "- Function ${function.name} must be a suspend function for EitherNet to work."
+    }
+    if (function.returnType.javaType.rawType != ApiResult::class.java) {
+      errors += "- Function ${function.name} must return ApiResult for EitherNet to work."
+    }
+    for (validator in validators) {
+      validator.validate(this, function, errors)
+    }
+  }
+
+  if (errors.isNotEmpty()) {
+    error("Service errors found for $simpleName\n${errors.joinToString("\n")}")
+  }
+}
+
+/**
+ * Creates a new [Proxy] instance of the given [T] API service that delegates to the underlying
+ * [orchestrator] for enqueued responses.
+ *
+ * This heavily mirrors Retrofit's own internal implementation of creating Proxies.
+ */
+@PublishedApi
+@Suppress("UNCHECKED_CAST")
+internal fun <T> newProxy(service: Class<T>, orchestrator: EitherNetTestOrchestrator): T {
+  return Proxy.newProxyInstance(
+    service.classLoader,
+    arrayOf(service),
+    object : InvocationHandler {
+      override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any? {
+        // If the method is a method from Object then defer to normal invocation.
+        val finalArgs = args.orEmpty()
+        if (method.declaringClass == Object::class.java) {
+          return method.invoke(this, *finalArgs)
+        }
+
+        return if (Companion.INSTANCE.isDefaultMethod(method)) {
+          Companion.INSTANCE.invokeDefaultMethod(method, service, proxy, finalArgs)
+        } else {
+          val key = createEndpointKey(method)
+          check(finalArgs.isNotEmpty()) {
+            "No arguments found on method ${key.name}, did you forget to add the 'suspend' modifier?"
+          }
+          val continuation = finalArgs.last()
+          check(continuation is Continuation<*>) {
+            "Last arg is not a Continuation, did you forget to add the 'suspend' modifier?"
+          }
+          val argsArray = Array(finalArgs.size - 1) { i -> finalArgs[i] }
+          val body = orchestrator.endpoints.getValue(key)
+            .removeFirstOrNull()
+            ?: error("No result enqueued for ${key.name}.")
+          CoroutineTransformer.transform(
+            argsArray,
+            body,
+            continuation as Continuation<ApiResult<*, *>>
+          )
+        }
+      }
+    }
+  ) as T
+}

--- a/src/testFixtures/java/com/slack/eithernet/test/EitherNetTestOrchestrator.kt
+++ b/src/testFixtures/java/com/slack/eithernet/test/EitherNetTestOrchestrator.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.eithernet.test
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Simple orchestration holder class to allow [endpoints] access between proxied APIs and
+ * [EitherNetController] instances.
+ */
+internal class EitherNetTestOrchestrator(
+  val endpoints: ConcurrentHashMap<EndpointKey, ArrayDeque<SuspendedResult>>
+)

--- a/src/testFixtures/java/com/slack/eithernet/test/EndpointKey.kt
+++ b/src/testFixtures/java/com/slack/eithernet/test/EndpointKey.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.eithernet.test
+
+import java.lang.reflect.Method
+
+/** A simple key for a given endpoint. */
+data class EndpointKey internal constructor(val name: String, val parameters: List<ParameterKey>)
+
+@PublishedApi
+internal fun createEndpointKey(method: Method): EndpointKey {
+  return EndpointKey(method.name, method.parameterTypes.mapNotNull(::createParameterKey))
+}

--- a/src/testFixtures/java/com/slack/eithernet/test/JavaEitherNetControllers.kt
+++ b/src/testFixtures/java/com/slack/eithernet/test/JavaEitherNetControllers.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:JvmName("JavaEitherNetControllers")
+
+package com.slack.eithernet.test
+
+import com.slack.eithernet.ApiResult
+import com.slack.eithernet.ExperimentalEitherNetApi
+import com.slack.eithernet.InternalEitherNetApi
+
+/** Enqueues a suspended [resultBody]. Note that this is not safe and only available for Java. */
+@ExperimentalEitherNetApi
+fun <T : Any, S : Any, E : Any> EitherNetController<T>.enqueueFromJava(
+  clazz: Class<T>,
+  methodName: String,
+  resultBody: ApiResult<S, E>
+) {
+  val method = clazz.declaredMethods.first { it.name == methodName }
+  val key = createEndpointKey(method)
+  @OptIn(InternalEitherNetApi::class)
+  unsafeEnqueue(key) { resultBody }
+}

--- a/src/testFixtures/java/com/slack/eithernet/test/ParameterKey.kt
+++ b/src/testFixtures/java/com/slack/eithernet/test/ParameterKey.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.eithernet.test
+
+import com.squareup.moshi.internal.Util
+import com.squareup.moshi.rawType
+import java.lang.reflect.Type
+import kotlin.coroutines.Continuation
+
+/** A simple parameter endpoint key for use with [EndpointKey]. */
+data class ParameterKey internal constructor(val type: Type)
+
+internal fun createParameterKey(parameterType: Type): ParameterKey? {
+  if (parameterType.rawType == Continuation::class.java) return null
+  return ParameterKey(
+    // Borrow an internal API from Moshi because it has nicer and more consistent Type
+    // implementations that use safer equality checks. This matches how Moshi internally keys
+    // cached adapters.
+    Util.canonicalize(parameterType)
+  )
+}

--- a/src/testFixtures/java/com/slack/eithernet/test/Platform.kt
+++ b/src/testFixtures/java/com/slack/eithernet/test/Platform.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2013 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.eithernet.test
+
+import android.annotation.SuppressLint
+import android.os.Build.VERSION
+import androidx.annotation.RequiresApi
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodHandles.Lookup
+import java.lang.reflect.Constructor
+import java.lang.reflect.Method
+
+/**
+ * Simple indirection for platform-specific implementations for Android and JVM. Adapted from
+ * Retrofit's internal version.
+ */
+internal open class Platform(private val hasJava8Types: Boolean) {
+  private val lookupConstructor: Constructor<Lookup>?
+
+  init {
+    var lookupConstructor: Constructor<Lookup>? = null
+    @RequiresApi(26)
+    if (hasJava8Types) {
+      try {
+        // Because the service interface might not be public, we need to use a MethodHandle lookup
+        // that ignores the visibility of the declaringClass.
+        lookupConstructor = Lookup::class.java.getDeclaredConstructor(
+          Class::class.java,
+          Int::class.javaPrimitiveType
+        )
+        lookupConstructor.setAccessible(true)
+      } catch (ignored: NoClassDefFoundError) {
+        // Android API 24 or 25 where Lookup doesn't exist. Calling default methods on non-public
+        // interfaces will fail, but there's nothing we can do about it.
+      } catch (ignored: NoSuchMethodException) {
+        // Assume JDK 14+ which contains a fix that allows a regular lookup to succeed.
+        // See https://bugs.openjdk.java.net/browse/JDK-8209005.
+      }
+    }
+    this.lookupConstructor = lookupConstructor
+  }
+
+  @SuppressLint("NewApi")
+  fun isDefaultMethod(method: Method): Boolean {
+    return hasJava8Types && method.isDefault
+  }
+
+  @SuppressLint("NewApi")
+  open fun invokeDefaultMethod(
+    method: Method,
+    declaringClass: Class<*>,
+    obj: Any,
+    vararg args: Any
+  ): Any? {
+    val lookup = if (lookupConstructor != null) {
+      lookupConstructor.newInstance(
+        declaringClass,
+        -1 /* trusted */
+      )
+    } else {
+      MethodHandles.lookup()
+    }
+    return lookup.unreflectSpecial(method, declaringClass)
+      .bindTo(obj)
+      .invokeWithArguments(*args)
+  }
+
+  internal class Android : Platform(VERSION.SDK_INT >= 24) {
+    override fun invokeDefaultMethod(
+      method: Method,
+      declaringClass: Class<*>,
+      obj: Any,
+      vararg args: Any
+    ): Any? {
+      if (VERSION.SDK_INT < 26) {
+        throw UnsupportedOperationException(
+          "Calling default methods on API 24 and 25 is not supported"
+        )
+      }
+      return super.invokeDefaultMethod(method, declaringClass, obj, *args)
+    }
+  }
+
+  companion object {
+    val INSTANCE by lazy {
+      findPlatform()
+    }
+
+    private fun findPlatform(): Platform {
+      return if ("Dalvik" == System.getProperty("java.vm.name")) {
+        Android()
+      } else {
+        Platform(true)
+      }
+    }
+  }
+}

--- a/src/testFixtures/java/com/slack/eithernet/test/RealEitherNetController.kt
+++ b/src/testFixtures/java/com/slack/eithernet/test/RealEitherNetController.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.eithernet.test
+
+import com.slack.eithernet.ApiResult
+import com.slack.eithernet.ExperimentalEitherNetApi
+import com.slack.eithernet.InternalEitherNetApi
+
+@OptIn(ExperimentalEitherNetApi::class)
+internal class RealEitherNetController<T : Any>(
+  private val orchestrator: EitherNetTestOrchestrator,
+  override val api: T,
+) : EitherNetController<T> {
+  @InternalEitherNetApi
+  override fun <S : Any, E : Any> unsafeEnqueue(
+    key: EndpointKey,
+    resultBody: suspend (args: Array<Any>) -> ApiResult<S, E>
+  ) {
+    orchestrator.endpoints.getValue(key).add(resultBody)
+  }
+
+  override fun assertNoMoreQueuedResults() {
+    val errors = mutableListOf<String>()
+    orchestrator.endpoints.forEach { (endpoint, resultsQueue) ->
+      if (resultsQueue.isNotEmpty()) {
+        val directObject = if (resultsQueue.size == 1) {
+          "result"
+        } else {
+          "results"
+        }
+        errors += "-- ${endpoint.name}() has ${resultsQueue.size} unprocessed $directObject"
+      }
+    }
+    if (errors.isNotEmpty()) {
+      throw AssertionError("Found unprocessed ApiResults:\n${errors.joinToString("\n")}")
+    }
+  }
+}

--- a/src/testFixtures/java/com/slack/eithernet/test/Util.kt
+++ b/src/testFixtures/java/com/slack/eithernet/test/Util.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.eithernet.test
+
+import com.slack.eithernet.ApiResult
+import kotlinx.coroutines.Dispatchers
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.intercepted
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.resumeWithException
+import kotlin.reflect.KFunction
+import kotlin.reflect.typeOf
+
+internal typealias SuspendedResult = suspend (args: Array<Any>) -> ApiResult<*, *>
+
+internal suspend fun SuspendedResult.awaitResponse(args: Array<Any>): ApiResult<*, *> = invoke(args)
+
+/**
+ * Force the calling coroutine to suspend before throwing [this].
+ *
+ * This is needed when a checked exception is synchronously caught in a [java.lang.reflect.Proxy]
+ * invocation to avoid being wrapped in [java.lang.reflect.UndeclaredThrowableException].
+ *
+ * The implementation is derived from:
+ * https://github.com/Kotlin/kotlinx.coroutines/pull/1667#issuecomment-556106349
+ */
+internal suspend fun Exception.suspendAndThrow(): Nothing {
+  suspendCoroutineUninterceptedOrReturn<Nothing> { continuation ->
+    Dispatchers.Default.dispatch(continuation.context) {
+      continuation.intercepted().resumeWithException(this@suspendAndThrow)
+    }
+    COROUTINE_SUSPENDED
+  }
+}
+
+/**
+ * Validates that the type declarations on [this] endpoint function's return type match the reified
+ * [S] and [E] types that [newEitherNetController] specifies. We do this in lieu of stronger type
+ * checking from the IDE, which appears to throw type checking out the window due to [ApiResult]'s
+ * use of covariant (i.e. `out`) types.
+ */
+@OptIn(ExperimentalStdlibApi::class)
+@PublishedApi
+internal inline fun <reified S : Any, reified E : Any> KFunction<ApiResult<S, E>>.validateTypes() {
+  // Note that we don't use Moshi's nicer canonicalize APIs because it would lose the Kotlin type
+  // information like nullability and intrinsic types.
+  val type = returnType
+  val (success, error) = type.arguments
+    .map { it.type!! }
+
+  check(success == typeOf<S>()) {
+    "Type check failed! Expected success type of '$success' but found '${typeOf<S>()}'. Ensure that your result type matches the target endpoint as the IDE won't correctly infer this!"
+  }
+  check(error == typeOf<E>()) {
+    "Type check failed! Expected error type of '$error' but found '${typeOf<E>()}'. Ensure that your result type matches the target endpoint as the IDE won't correctly infer this!"
+  }
+}


### PR DESCRIPTION
This upstreams our internal `EitherNetController` API and exposes them as a Gradle test fixture, allowing consumers to use this for their own test needs.

These are guarded by a new `@ExperimentalEitherNetApi`.