### PR TITLE
Add exception to ApiResult.Failure

### DIFF
--- a/src/test/kotlin/com/slack/eithernet/ApiResultTest.kt
+++ b/src/test/kotlin/com/slack/eithernet/ApiResultTest.kt
@@ -101,6 +101,7 @@ class ApiResultTest {
     check(result is HttpFailure)
     assertThat(result.code).isEqualTo(404)
     assertThat(result.error).isNull()
+    assertThat(result.exception).hasMessageThat().startsWith("HTTP 404")
 
     // Assert tags
     assertThat(result.request()).isNotNull()
@@ -185,6 +186,7 @@ class ApiResultTest {
     val result = runBlocking { service.testEndpoint() }
     check(result is ApiFailure)
     assertThat(result.error).isEqualTo(errorMessage)
+    assertThat(result.exception.error).isEqualTo(errorMessage)
 
     // Assert tags
     assertThat(result.request()).isNotNull()
@@ -280,6 +282,13 @@ class ApiResultTest {
     } catch (e: IllegalArgumentException) {
       assertThat(e).hasMessageThat().contains("Must be a 4xx or 5xx code")
     }
+  }
+
+  @Test
+  fun failure_exposes_exception() {
+    val exception = Exception()
+    val failure: ApiResult.Failure<Nothing> = ApiResult.unknownFailure(exception)
+    assertThat(failure.exception).isSameInstanceAs(exception)
   }
 
   @Test


### PR DESCRIPTION
###  Summary

Add an exception field to `ApiResult.Failure`. This is useful for logging and when there is no distinct handling between some Failure subtypes.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/eithernet/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).