### PR TITLE
Readme: use Unit for no custom error type

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ val api = Retrofit.Builder()
   .create<TestApi>()
 ```
 
-If you don't have custom error return types, simply use `Nothing` for the error type.
+If you don't have custom error return types, simply use `Unit` for the error type.
 
 ### Decoding Error Bodies
 


### PR DESCRIPTION
###  Summary

Correction based on the discussion in https://github.com/slackhq/EitherNet/issues/19

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/eithernet/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).