### PR TITLE
Fix exception on annotation traversal when target is not present

### DIFF
--- a/src/main/java/com/slack/eithernet/Annotations.kt
+++ b/src/main/java/com/slack/eithernet/Annotations.kt
@@ -80,7 +80,7 @@ private fun <A : Any> Array<out Annotation>.nextAnnotations(type: Class<A>): Pai
     if (type.isInstance(next)) {
       @Suppress("UNCHECKED_CAST")
       resultType = next as A
-    } else {
+    } else if (nextIndex < nextAnnotations.size) {
       nextAnnotations[nextIndex] = next
       nextIndex++
     }
@@ -90,7 +90,7 @@ private fun <A : Any> Array<out Annotation>.nextAnnotations(type: Class<A>): Pai
     @Suppress("UNCHECKED_CAST")
     resultType to (nextAnnotations as Array<Annotation>)
   } else {
-    null
+    null to theseAnnotations
   }
 }
 

--- a/src/main/java/com/slack/eithernet/Annotations.kt
+++ b/src/main/java/com/slack/eithernet/Annotations.kt
@@ -90,7 +90,7 @@ private fun <A : Any> Array<out Annotation>.nextAnnotations(type: Class<A>): Pai
     @Suppress("UNCHECKED_CAST")
     resultType to (nextAnnotations as Array<Annotation>)
   } else {
-    null to theseAnnotations
+    null
   }
 }
 

--- a/src/test/kotlin/com/slack/eithernet/ResultTypeTest.kt
+++ b/src/test/kotlin/com/slack/eithernet/ResultTypeTest.kt
@@ -62,7 +62,7 @@ class ResultTypeTest {
   }
 
   @Test
-  fun errorType() {
+  fun errorType_present() {
     val annotations = Array<Annotation>(4) {
       ResultTypeTest::class.java.getAnnotation(SampleAnnotation::class.java)
     }
@@ -74,7 +74,15 @@ class ResultTypeTest {
   }
 
   @Test
-  fun statusCode() {
+  fun errorType_absent() {
+    val annotations = Array<Annotation>(4) {
+      ResultTypeTest::class.java.getAnnotation(SampleAnnotation::class.java)
+    }
+    assertThat(annotations.errorType()).isNull()
+  }
+
+  @Test
+  fun statusCode_present() {
     val annotations = Array<Annotation>(4) {
       ResultTypeTest::class.java.getAnnotation(SampleAnnotation::class.java)
     }
@@ -83,6 +91,14 @@ class ResultTypeTest {
     val (statusCode, nextAnnotations) = annotations.statusCode() ?: error("No annotation found")
     assertThat(nextAnnotations.size).isEqualTo(3)
     assertThat(statusCode).isSameInstanceAs(statusCodeAnnotation)
+  }
+
+  @Test
+  fun statusCode_absent() {
+    val annotations = Array<Annotation>(4) {
+      ResultTypeTest::class.java.getAnnotation(SampleAnnotation::class.java)
+    }
+    assertThat(annotations.statusCode()).isNull()
   }
 
   private class A


### PR DESCRIPTION
###  Summary

Resolves [issues/50](https://github.com/slackhq/EitherNet/issues/50).

As soon as we reach the end of `nextAnnotations`, we avoid an illegal array access. Since this is the last iteration, it's implied that `resultType` will be `null`.

Another potential approach would be to check if the target annotation is in the original array first, and if so, we could create a new filtered copy, but I assume this is not desired so we can keep running a single array traversal.

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/eithernet/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).