### PR TITLE
Implement retryWithExponentialBackoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ A common pattern in making network requests is to retry with exponential backoff
 ```kotlin
 // Defaults for reference
 val result = retryWithExponentialBackoff(
-  maxAttempts = 5,
-  initialDelay = 1.seconds,
+  maxAttempts = 3,
+  initialDelay = 500.milliseconds,
   delayFactor = 2.0,
-  maxDelay = 1.hours,
-  jitterFactor = 0.0,
+  maxDelay = 10.seconds,
+  jitterFactor = 0.25,
   onFailure = null, // Optional Failure callback w/ attempt
 ) {
     api.getData()

--- a/README.md
+++ b/README.md
@@ -146,6 +146,24 @@ class ErrorConverterFactory : Converter.Factory() {
 }
 ```
 
+### Retries
+
+A common pattern in making network requests is to retry with exponential backoff. EitherNet ships with a highly configurable `retryWithExponentialBackoff()` function for this case.
+
+```kotlin
+// Defaults for reference
+val result = retryWithExponentialBackoff(
+  maxAttempts = 5,
+  initialDelay = 1.seconds,
+  delayFactor = 2.0,
+  maxDelay = Duration.INFINITE,
+  jitterFactor = 0.0,
+  onFailure = null, // Optional Failure callback w/ attempt
+) {
+    api.getData()
+}
+```
+
 ## Testing
 
 EitherNet ships with a [Test Fixtures](https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures)

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ val result = retryWithExponentialBackoff(
   delayFactor = 2.0,
   maxDelay = 10.seconds,
   jitterFactor = 0.25,
-  onFailure = null, // Optional Failure callback w/ attempt
+  onFailure = null, // Optional Failure callback for logging
 ) {
     api.getData()
 }

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ val result = retryWithExponentialBackoff(
   maxAttempts = 5,
   initialDelay = 1.seconds,
   delayFactor = 2.0,
-  maxDelay = Duration.INFINITE,
+  maxDelay = 1.hours,
   jitterFactor = 0.0,
   onFailure = null, // Optional Failure callback w/ attempt
 ) {

--- a/api/eithernet.api
+++ b/api/eithernet.api
@@ -81,8 +81,8 @@ public abstract interface annotation class com/slack/eithernet/ResultType : java
 }
 
 public final class com/slack/eithernet/RetriesKt {
-	public static final fun retryWithExponentialBackoff-3FA4DCs (IJDJDLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun retryWithExponentialBackoff-3FA4DCs$default (IJDJDLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun retryWithExponentialBackoff-3FA4DCs (IJDJDLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun retryWithExponentialBackoff-3FA4DCs$default (IJDJDLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface annotation class com/slack/eithernet/StatusCode : java/lang/annotation/Annotation {

--- a/api/eithernet.api
+++ b/api/eithernet.api
@@ -80,6 +80,11 @@ public abstract interface annotation class com/slack/eithernet/ResultType : java
 	public abstract fun typeArgs ()[Lcom/slack/eithernet/ResultType;
 }
 
+public final class com/slack/eithernet/RetriesKt {
+	public static final fun retryWithExponentialBackoff-3FA4DCs (IJDJDLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun retryWithExponentialBackoff-3FA4DCs$default (IJDJDLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public abstract interface annotation class com/slack/eithernet/StatusCode : java/lang/annotation/Annotation {
 	public abstract fun value ()I
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,6 +109,7 @@ project.version = project.property("VERSION_NAME").toString()
 
 dependencies {
   implementation(libs.retrofit)
+  implementation(libs.coroutines.core)
 
   testImplementation(libs.coroutines.core)
   testImplementation(libs.coroutines.test)

--- a/src/main/java/com/slack/eithernet/Retries.kt
+++ b/src/main/java/com/slack/eithernet/Retries.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.delay
  * use case, you might want to customize the strategy, for example by handling certain kinds of
  * failures differently.
  */
+@Suppress("LongParameterList", "ReturnCount")
 public suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
   maxAttempts: Int = 5,
   initialDelay: Duration = 1.seconds,

--- a/src/main/java/com/slack/eithernet/Retries.kt
+++ b/src/main/java/com/slack/eithernet/Retries.kt
@@ -80,5 +80,5 @@ public suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
       }
     }
   }
-  return ApiResult.unknownFailure(RuntimeException("Max attempts reached"))
+  error("Not reachable")
 }

--- a/src/main/java/com/slack/eithernet/Retries.kt
+++ b/src/main/java/com/slack/eithernet/Retries.kt
@@ -18,7 +18,7 @@ package com.slack.eithernet
 import kotlin.math.nextUp
 import kotlin.random.Random
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.times
 import kotlinx.coroutines.delay
@@ -36,24 +36,23 @@ import kotlinx.coroutines.delay
  * use case, you might want to customize the strategy, for example by handling certain kinds of
  * failures differently.
  *
- * @param maxAttempts The maximum number of times to retry the operation. Default is 5.
- * @param initialDelay The delay before the first retry. Default is 1 second.
+ * @param maxAttempts The maximum number of times to retry the operation.
+ * @param initialDelay The delay before the first retry.
  * @param delayFactor The factor by which the delay should increase after each failed attempt.
- *   Default is 2.0.
- * @param maxDelay The maximum delay between retries. Default is 1 hour.
+ * @param maxDelay The maximum delay between retries.
  * @param jitterFactor The maximum factor of jitter to introduce. For example, a value of 0.1 will
- *   introduce up to 10% jitter (both positive and negative). Default is 0.
+ *   introduce up to 10% jitter (both positive and negative).
  * @param onFailure An optional callback for failures, useful for logging.
  * @return The result of the operation if it's successful, or the last failure result if all
  *   attempts fail.
  */
 @Suppress("LongParameterList")
 public tailrec suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
-  maxAttempts: Int = 5,
-  initialDelay: Duration = 1.seconds,
+  maxAttempts: Int = 3,
+  initialDelay: Duration = 500.milliseconds,
   delayFactor: Double = 2.0,
-  maxDelay: Duration = 1.hours,
-  jitterFactor: Double = 0.0,
+  maxDelay: Duration = 10.seconds,
+  jitterFactor: Double = 0.25,
   onFailure: ((attempt: Int, result: ApiResult.Failure<E>) -> Unit)? = null,
   block: suspend () -> ApiResult<T, E>
 ): ApiResult<T, E> {

--- a/src/main/java/com/slack/eithernet/Retries.kt
+++ b/src/main/java/com/slack/eithernet/Retries.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.eithernet
+
+import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+
+/**
+ * Retries a [block] of code with exponential backoff.
+ *
+ * @param maxAttempts The maximum number of times to retry the operation. Default is 5.
+ * @param initialDelay The delay before the first retry. Default is 100 milliseconds.
+ * @param maxDelay The maximum delay between retries. Default is 10,000 milliseconds.
+ * @param factor The factor by which the delay should increase after each failed attempt. Default is
+ *   2.0.
+ * @param jitterFactor The maximum factor of jitter to introduce. For example, a value of 0.1 will
+ *   introduce up to 10% jitter. Default is 0.
+ * @param block The block of code to retry. This block should return an [ApiResult].
+ * @return The result of the operation if it's successful, or the last failure result if all
+ *   attempts fail.
+ *
+ * This function will attempt the operation you give it up to [maxAttempts] times, multiplying the
+ * delay between each attempt by [factor], starting from [initialDelay] and not exceeding
+ * [maxDelay]. If the operation continues to fail after [maxAttempts] times, it will return the last
+ * failure result. If the operation succeeds at any point, it will immediately return the success
+ * result.
+ *
+ * Note: This uses a default exponential backoff strategy with optional jitter. Depending on your
+ * use case, you might want to customize the strategy, for example by handling certain kinds of
+ * failures differently.
+ */
+public suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
+  maxAttempts: Int = 5,
+  initialDelay: Duration = 1.seconds,
+  maxDelay: Duration = 20.seconds,
+  factor: Double = 2.0,
+  jitterFactor: Double = 0.0,
+  block: suspend () -> ApiResult<T, E>
+): ApiResult<T, E> {
+  require(maxAttempts > 0) { "maxAttempts must be greater than 0" }
+  var currentDelay = initialDelay
+  repeat(maxAttempts) { attempt ->
+    when (val result = block()) {
+      is ApiResult.Success -> return result
+      is ApiResult.Failure -> {
+        // TODO expose a logging hook here?
+        if (attempt == maxAttempts - 1) {
+          return result // return last failure
+        } else {
+          delay(currentDelay)
+          // Compute a new delay using a combination of the factor and optional jitter.
+          currentDelay = (currentDelay * factor).coerceAtMost(maxDelay)
+          if (jitterFactor != 0.0) {
+            // Note that Random.nextDouble requires a range,
+            // so we provide it with -jitterFactor to jitterFactor.
+            // It also cannot be 0, so only do this if jitter is non-zero
+            val jitter = 1 + Random.nextDouble(-jitterFactor, jitterFactor)
+            currentDelay = (currentDelay * jitter).coerceAtMost(maxDelay)
+          }
+        }
+      }
+    }
+  }
+  return ApiResult.unknownFailure(RuntimeException("Max attempts reached"))
+}

--- a/src/main/java/com/slack/eithernet/Retries.kt
+++ b/src/main/java/com/slack/eithernet/Retries.kt
@@ -53,7 +53,7 @@ public tailrec suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
   delayFactor: Double = 2.0,
   maxDelay: Duration = 10.seconds,
   jitterFactor: Double = 0.25,
-  onFailure: ((attemptsRemaining: Int, result: ApiResult.Failure<E>) -> Unit)? = null,
+  onFailure: ((failure: ApiResult.Failure<E>) -> Unit)? = null,
   block: suspend () -> ApiResult<T, E>
 ): ApiResult<T, E> {
   require(maxAttempts > 0) { "maxAttempts must be greater than 0" }
@@ -62,7 +62,7 @@ public tailrec suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
     is ApiResult.Success -> result
     is ApiResult.Failure -> {
       val attemptsRemaining = maxAttempts - 1
-      onFailure?.invoke(attemptsRemaining, result)
+      onFailure?.invoke(result)
       if (attemptsRemaining == 0) {
         result
       } else {

--- a/src/main/java/com/slack/eithernet/Retries.kt
+++ b/src/main/java/com/slack/eithernet/Retries.kt
@@ -19,6 +19,7 @@ import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.hours
 
 /**
  * Retries a [block] of code with exponential backoff.
@@ -27,7 +28,7 @@ import kotlinx.coroutines.delay
  * @param initialDelay The delay before the first retry. Default is 1 second.
  * @param delayFactor The factor by which the delay should increase after each failed attempt.
  *   Default is 2.0.
- * @param maxDelay The maximum delay between retries. Default is [Duration.INFINITE].
+ * @param maxDelay The maximum delay between retries. Default is 1 hour.
  * @param jitterFactor The maximum factor of jitter to introduce. For example, a value of 0.1 will
  *   introduce up to 10% jitter. Default is 0.
  * @param onFailure An optional callback for failures, useful for logging.
@@ -50,7 +51,7 @@ public suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
   maxAttempts: Int = 5,
   initialDelay: Duration = 1.seconds,
   delayFactor: Double = 2.0,
-  maxDelay: Duration = Duration.INFINITE,
+  maxDelay: Duration = 1.hours,
   jitterFactor: Double = 0.0,
   onFailure: ((attempt: Int, result: ApiResult.Failure<E>) -> Unit)? = null,
   block: suspend () -> ApiResult<T, E>

--- a/src/main/java/com/slack/eithernet/Retries.kt
+++ b/src/main/java/com/slack/eithernet/Retries.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.delay
  * @param jitterFactor The maximum factor of jitter to introduce. For example, a value of 0.1 will
  *   introduce up to 10% jitter. Default is 0.
  * @param onFailure An optional callback for failures, useful for logging.
- * @param block The block of code to retry. This block should return an [ApiResult].
+ *
  * @return The result of the operation if it's successful, or the last failure result if all
  *   attempts fail.
  */

--- a/src/main/java/com/slack/eithernet/Retries.kt
+++ b/src/main/java/com/slack/eithernet/Retries.kt
@@ -24,10 +24,10 @@ import kotlinx.coroutines.delay
  * Retries a [block] of code with exponential backoff.
  *
  * @param maxAttempts The maximum number of times to retry the operation. Default is 5.
- * @param initialDelay The delay before the first retry. Default is 100 milliseconds.
- * @param maxDelay The maximum delay between retries. Default is 10,000 milliseconds.
+ * @param initialDelay The delay before the first retry. Default is 1 second.
  * @param factor The factor by which the delay should increase after each failed attempt. Default is
  *   2.0.
+ * @param maxDelay The maximum delay between retries. Default is [Duration.INFINITE].
  * @param jitterFactor The maximum factor of jitter to introduce. For example, a value of 0.1 will
  *   introduce up to 10% jitter. Default is 0.
  * @param onFailure An optional callback for failures, useful for logging.
@@ -48,8 +48,8 @@ import kotlinx.coroutines.delay
 public suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
   maxAttempts: Int = 5,
   initialDelay: Duration = 1.seconds,
-  maxDelay: Duration = 20.seconds,
   factor: Double = 2.0,
+  maxDelay: Duration = Duration.INFINITE,
   jitterFactor: Double = 0.0,
   onFailure: ((attempt: Int, result: ApiResult.Failure<E>) -> Unit)? = null,
   block: suspend () -> ApiResult<T, E>

--- a/src/main/java/com/slack/eithernet/Retries.kt
+++ b/src/main/java/com/slack/eithernet/Retries.kt
@@ -17,12 +17,22 @@ package com.slack.eithernet
 
 import kotlin.random.Random
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
-import kotlin.time.Duration.Companion.hours
 
 /**
  * Retries a [block] of code with exponential backoff.
+ *
+ * This function will attempt the operation you give it up to [maxAttempts] times, multiplying the
+ * delay between each attempt by [delayFactor], starting from [initialDelay] and not exceeding
+ * [maxDelay]. If the operation continues to fail after [maxAttempts] times, it will return the last
+ * failure result. If the operation succeeds at any point, it will immediately return the success
+ * result.
+ *
+ * Note: This uses a default exponential backoff strategy with optional jitter. Depending on your
+ * use case, you might want to customize the strategy, for example by handling certain kinds of
+ * failures differently.
  *
  * @param maxAttempts The maximum number of times to retry the operation. Default is 5.
  * @param initialDelay The delay before the first retry. Default is 1 second.
@@ -35,16 +45,6 @@ import kotlin.time.Duration.Companion.hours
  * @param block The block of code to retry. This block should return an [ApiResult].
  * @return The result of the operation if it's successful, or the last failure result if all
  *   attempts fail.
- *
- * This function will attempt the operation you give it up to [maxAttempts] times, multiplying the
- * delay between each attempt by [delayFactor], starting from [initialDelay] and not exceeding
- * [maxDelay]. If the operation continues to fail after [maxAttempts] times, it will return the last
- * failure result. If the operation succeeds at any point, it will immediately return the success
- * result.
- *
- * Note: This uses a default exponential backoff strategy with optional jitter. Depending on your
- * use case, you might want to customize the strategy, for example by handling certain kinds of
- * failures differently.
  */
 @Suppress("LongParameterList", "ReturnCount")
 public suspend fun <T : Any, E : Any> retryWithExponentialBackoff(

--- a/src/main/java/com/slack/eithernet/Retries.kt
+++ b/src/main/java/com/slack/eithernet/Retries.kt
@@ -47,13 +47,35 @@ import kotlinx.coroutines.delay
  *   attempts fail.
  */
 @Suppress("LongParameterList")
-public tailrec suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
+public suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
   maxAttempts: Int = 5,
   initialDelay: Duration = 1.seconds,
   delayFactor: Double = 2.0,
   maxDelay: Duration = 1.hours,
   jitterFactor: Double = 0.0,
-  attempt: Int = 0,
+  onFailure: ((attempt: Int, result: ApiResult.Failure<E>) -> Unit)? = null,
+  block: suspend () -> ApiResult<T, E>
+): ApiResult<T, E> {
+  return retryWithExponentialBackoff(
+    maxAttempts = maxAttempts,
+    initialDelay = initialDelay,
+    delayFactor = delayFactor,
+    maxDelay = maxDelay,
+    jitterFactor = jitterFactor,
+    onFailure = onFailure,
+    attempt = 0,
+    block = block
+  )
+}
+
+@Suppress("LongParameterList")
+private tailrec suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
+  maxAttempts: Int,
+  initialDelay: Duration,
+  delayFactor: Double,
+  maxDelay: Duration,
+  jitterFactor: Double,
+  attempt: Int,
   onFailure: ((attempt: Int, result: ApiResult.Failure<E>) -> Unit)? = null,
   block: suspend () -> ApiResult<T, E>
 ): ApiResult<T, E> {

--- a/src/main/java/com/slack/eithernet/Retries.kt
+++ b/src/main/java/com/slack/eithernet/Retries.kt
@@ -53,7 +53,7 @@ public tailrec suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
   delayFactor: Double = 2.0,
   maxDelay: Duration = 10.seconds,
   jitterFactor: Double = 0.25,
-  onFailure: ((attempt: Int, result: ApiResult.Failure<E>) -> Unit)? = null,
+  onFailure: ((attemptsRemaining: Int, result: ApiResult.Failure<E>) -> Unit)? = null,
   block: suspend () -> ApiResult<T, E>
 ): ApiResult<T, E> {
   require(maxAttempts > 0) { "maxAttempts must be greater than 0" }
@@ -61,8 +61,8 @@ public tailrec suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
   return when (val result = block()) {
     is ApiResult.Success -> result
     is ApiResult.Failure -> {
-      onFailure?.invoke(maxAttempts, result)
       val attemptsRemaining = maxAttempts - 1
+      onFailure?.invoke(attemptsRemaining, result)
       if (attemptsRemaining == 0) {
         result
       } else {

--- a/src/main/java/com/slack/eithernet/Retries.kt
+++ b/src/main/java/com/slack/eithernet/Retries.kt
@@ -25,8 +25,8 @@ import kotlinx.coroutines.delay
  *
  * @param maxAttempts The maximum number of times to retry the operation. Default is 5.
  * @param initialDelay The delay before the first retry. Default is 1 second.
- * @param factor The factor by which the delay should increase after each failed attempt. Default is
- *   2.0.
+ * @param delayFactor The factor by which the delay should increase after each failed attempt.
+ *   Default is 2.0.
  * @param maxDelay The maximum delay between retries. Default is [Duration.INFINITE].
  * @param jitterFactor The maximum factor of jitter to introduce. For example, a value of 0.1 will
  *   introduce up to 10% jitter. Default is 0.
@@ -36,7 +36,7 @@ import kotlinx.coroutines.delay
  *   attempts fail.
  *
  * This function will attempt the operation you give it up to [maxAttempts] times, multiplying the
- * delay between each attempt by [factor], starting from [initialDelay] and not exceeding
+ * delay between each attempt by [delayFactor], starting from [initialDelay] and not exceeding
  * [maxDelay]. If the operation continues to fail after [maxAttempts] times, it will return the last
  * failure result. If the operation succeeds at any point, it will immediately return the success
  * result.
@@ -48,7 +48,7 @@ import kotlinx.coroutines.delay
 public suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
   maxAttempts: Int = 5,
   initialDelay: Duration = 1.seconds,
-  factor: Double = 2.0,
+  delayFactor: Double = 2.0,
   maxDelay: Duration = Duration.INFINITE,
   jitterFactor: Double = 0.0,
   onFailure: ((attempt: Int, result: ApiResult.Failure<E>) -> Unit)? = null,
@@ -66,7 +66,7 @@ public suspend fun <T : Any, E : Any> retryWithExponentialBackoff(
         } else {
           delay(currentDelay)
           // Compute a new delay using a combination of the factor and optional jitter.
-          currentDelay = (currentDelay * factor).coerceAtMost(maxDelay)
+          currentDelay = (currentDelay * delayFactor).coerceAtMost(maxDelay)
           if (jitterFactor != 0.0) {
             // Note that Random.nextDouble requires a range,
             // so we provide it with -jitterFactor to jitterFactor.

--- a/src/test/kotlin/com/slack/eithernet/RetriesTest.kt
+++ b/src/test/kotlin/com/slack/eithernet/RetriesTest.kt
@@ -93,7 +93,7 @@ class RetriesTest {
     var attempts = 0
     val delays = mutableListOf<Long>()
     var lastAttemptTime = currentTime
-    retryWithExponentialBackoff(factor = 1.0, jitterFactor = 0.5) {
+    retryWithExponentialBackoff(delayFactor = 1.0, jitterFactor = 0.5) {
       attempts++
       if (attempts > 1) {
         val delay = currentTime - lastAttemptTime
@@ -111,7 +111,7 @@ class RetriesTest {
     var attempts = 0
     val delays = mutableListOf<Long>()
     var lastAttemptTime = currentTime
-    retryWithExponentialBackoff(factor = 1.0, jitterFactor = 0.0) {
+    retryWithExponentialBackoff(delayFactor = 1.0, jitterFactor = 0.0) {
       attempts++
       if (attempts > 1) {
         val delay = currentTime - lastAttemptTime

--- a/src/test/kotlin/com/slack/eithernet/RetriesTest.kt
+++ b/src/test/kotlin/com/slack/eithernet/RetriesTest.kt
@@ -56,12 +56,12 @@ class RetriesTest {
   @Test
   fun `log failed attempts`() = runTest {
     var attempts = 0
-    val recordedAttempts = mutableListOf<Int>()
+    val recordedAttempts = mutableListOf<ApiResult.Failure<Unit>>()
     val expectedException = RuntimeException("error")
     val result =
       retryWithExponentialBackoff<String, Unit>(
         maxAttempts = 3,
-        onFailure = { attempt, _ -> recordedAttempts.add(attempt) }
+        onFailure = { failure -> recordedAttempts.add(failure) }
       ) {
         attempts++
         ApiResult.unknownFailure(expectedException)

--- a/src/test/kotlin/com/slack/eithernet/RetriesTest.kt
+++ b/src/test/kotlin/com/slack/eithernet/RetriesTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.eithernet
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class RetriesTest {
+
+  @Test
+  fun `retry until success`() = runTest {
+    var attempts = 0
+    val expectedResult = ApiResult.success("result")
+    val result = retryWithExponentialBackoff {
+      attempts++
+      if (attempts < 3) {
+        ApiResult.unknownFailure(RuntimeException("error"))
+      } else {
+        expectedResult
+      }
+    }
+    assertThat(result).isEqualTo(expectedResult)
+    assertThat(attempts).isEqualTo(3)
+  }
+
+  @Test
+  fun `reach max attempts`() = runTest {
+    var attempts = 0
+    val expectedException = RuntimeException("error")
+    val result =
+      retryWithExponentialBackoff<String, Unit>(maxAttempts = 3) {
+        attempts++
+        ApiResult.unknownFailure(expectedException)
+      }
+    check(result is ApiResult.Failure.UnknownFailure)
+    assertThat(result.error).isEqualTo(expectedException)
+    assertThat(attempts).isEqualTo(3)
+  }
+
+  @Test
+  fun `does not exceed max delay`() = runTest {
+    var attempts = 0
+    var lastAttemptTime = currentTime
+    retryWithExponentialBackoff(initialDelay = 100.milliseconds, maxDelay = 500.milliseconds) {
+      attempts++
+      if (attempts > 1) {
+        val delay = currentTime - lastAttemptTime
+        assertThat(delay >= 100).isTrue()
+        assertThat(delay <= 500).isTrue()
+      }
+      lastAttemptTime = currentTime
+      ApiResult.unknownFailure(RuntimeException("error"))
+    }
+  }
+
+  @Test
+  fun `applies jitter results in different delays`() = runTest {
+    var attempts = 0
+    val delays = mutableListOf<Long>()
+    var lastAttemptTime = currentTime
+    retryWithExponentialBackoff(factor = 1.0, jitterFactor = 0.5) {
+      attempts++
+      if (attempts > 1) {
+        val delay = currentTime - lastAttemptTime
+        lastAttemptTime = currentTime
+        delays.add(delay)
+      }
+      ApiResult.unknownFailure(RuntimeException("error"))
+    }
+    // Check that delays are not all the same, which would indicate that jitter was not applied
+    assertThat(delays.distinct().size).isEqualTo(delays.size)
+  }
+
+  @Test
+  fun `does not apply jitter when jitter factor is 0`() = runTest {
+    var attempts = 0
+    val delays = mutableListOf<Long>()
+    var lastAttemptTime = currentTime
+    retryWithExponentialBackoff(factor = 1.0, jitterFactor = 0.0) {
+      attempts++
+      if (attempts > 1) {
+        val delay = currentTime - lastAttemptTime
+        lastAttemptTime = currentTime
+        delays.add(delay)
+      }
+      ApiResult.unknownFailure(RuntimeException("error"))
+    }
+    // Check that all delays are the same, which would indicate that jitter was not applied
+    assertThat(delays.distinct().size).isEqualTo(1)
+  }
+}


### PR DESCRIPTION
This adds a new `retryWithExponentialBackoff` utility for working with eithernet endpoints.

```kotlin
val result = retryWithExponentialBackoff {
  myApi.getStuff()
}
```

It supports customizable max attempts, initial delay, max delay, delay factor, failure logging, and even a jitter factor. Another bonus - A good chunk of this was suggested by ChatGPT based on its understanding of this library, including the tests!