### PR TITLE
Fix NPE crash when body is null due to Http code 204 or 205

### DIFF
--- a/src/main/java/com/slack/eithernet/ApiResult.kt
+++ b/src/main/java/com/slack/eithernet/ApiResult.kt
@@ -308,6 +308,7 @@ public object ApiResultCallAdapterFactory : CallAdapter.Factory() {
                   val withTag =
                     when (val result = response.body()) {
                       is Success -> result.withTags(result.tags + tags)
+                      null -> ApiResult.success(Unit).withTags(emptyMap<KClass<*>, Any>() + tags)
                       else -> null
                     }
                   callback.onResponse(call, Response.success(withTag))

--- a/src/test/kotlin/com/slack/eithernet/ApiResultTest.kt
+++ b/src/test/kotlin/com/slack/eithernet/ApiResultTest.kt
@@ -87,6 +87,16 @@ class ApiResultTest {
   }
 
   @Test
+  fun successWithUnitWithNullBody() = runTest {
+    val response = MockResponse().setResponseCode(204)
+
+    server.enqueue(response)
+    val result = service.unitEndpoint()
+    check(result is Success)
+    assertThat(result.value).isEqualTo(Unit)
+  }
+
+  @Test
   fun failureWithUnit() = runTest {
     val response = MockResponse().setResponseCode(404).setBody("Ignored errors!")
 


### PR DESCRIPTION
###  Summary

Fixes issue https://github.com/slackhq/EitherNet/issues/62
When http code is 204 or 205, retrofit passes null body, this fixes it by creating a success ApiResult with Unit

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/eithernet/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).