### PR TITLE
Add successOrNothing and exceptionOrNull extensions

### DIFF
--- a/api/eithernet.api
+++ b/api/eithernet.api
@@ -71,9 +71,11 @@ public abstract interface annotation class com/slack/eithernet/ExperimentalEithe
 }
 
 public final class com/slack/eithernet/ExtensionsKt {
+	public static final fun exceptionOrNull (Lcom/slack/eithernet/ApiResult$Failure;)Ljava/lang/Throwable;
 	public static final fun fold (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun fold (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun successOrElse (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun successOrNothing (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun successOrNull (Lcom/slack/eithernet/ApiResult;)Ljava/lang/Object;
 }
 

--- a/src/main/java/com/slack/eithernet/Extensions.kt
+++ b/src/main/java/com/slack/eithernet/Extensions.kt
@@ -50,8 +50,8 @@ public inline fun <T : Any, E : Any> ApiResult<T, E>.successOrNothing(
  * Returns the encapsulated [Throwable] exception of this failure type if one is available or null
  * if none are available.
  *
- * Note that if this is [ApiResult.Failure.HttpFailure] or [ApiResult.Failure.ApiFailure], the `error`
- * property will be returned IFF it's a [Throwable].
+ * Note that if this is [ApiResult.Failure.HttpFailure] or [ApiResult.Failure.ApiFailure], the
+ * `error` property will be returned IFF it's a [Throwable].
  */
 public fun <E : Any> ApiResult.Failure<E>.exceptionOrNull(): Throwable? {
   return when (this) {

--- a/src/main/java/com/slack/eithernet/Extensions.kt
+++ b/src/main/java/com/slack/eithernet/Extensions.kt
@@ -39,7 +39,7 @@ public inline fun <T : Any, E : Any> ApiResult<T, E>.successOrElse(
  * failure.
  */
 public inline fun <T : Any, E : Any> ApiResult<T, E>.successOrNothing(
-  body: (ApiResult.Failure<E>) -> T
+  body: (ApiResult.Failure<E>) -> Nothing
 ): T =
   when (this) {
     is ApiResult.Success -> value

--- a/src/main/java/com/slack/eithernet/Extensions.kt
+++ b/src/main/java/com/slack/eithernet/Extensions.kt
@@ -36,7 +36,7 @@ public inline fun <T : Any, E : Any> ApiResult<T, E>.successOrElse(
 
 /**
  * If [ApiResult.Success], returns the underlying [T] value. Otherwise, calls [body] with the
- * failure.
+ * failure, which can either throw an exception or return early (since this function is inline).
  */
 public inline fun <T : Any, E : Any> ApiResult<T, E>.successOrNothing(
   body: (ApiResult.Failure<E>) -> Nothing

--- a/src/main/java/com/slack/eithernet/Extensions.kt
+++ b/src/main/java/com/slack/eithernet/Extensions.kt
@@ -34,6 +34,34 @@ public inline fun <T : Any, E : Any> ApiResult<T, E>.successOrElse(
     is ApiResult.Failure -> defaultValue(this)
   }
 
+/**
+ * If [ApiResult.Success], returns the underlying [T] value. Otherwise, calls [body] with the
+ * failure.
+ */
+public inline fun <T : Any, E : Any> ApiResult<T, E>.successOrNothing(
+  body: (ApiResult.Failure<E>) -> T
+): T =
+  when (this) {
+    is ApiResult.Success -> value
+    is ApiResult.Failure -> body(this)
+  }
+
+/**
+ * Returns the encapsulated [Throwable] exception of this failure type if one is available or null
+ * if none are available.
+ *
+ * Note that if this is [ApiResult.Failure.HttpFailure] or [ApiResult.Failure.ApiFailure], the `error`
+ * property will be returned IFF it's a [Throwable].
+ */
+public fun <E : Any> ApiResult.Failure<E>.exceptionOrNull(): Throwable? {
+  return when (this) {
+    is ApiResult.Failure.NetworkFailure -> error
+    is ApiResult.Failure.UnknownFailure -> error
+    is ApiResult.Failure.HttpFailure -> error as? Throwable?
+    is ApiResult.Failure.ApiFailure -> error as? Throwable?
+  }
+}
+
 /** Transforms an [ApiResult] into a [C] value. */
 public fun <T : Any, E : Any, C> ApiResult<T, E>.fold(
   onSuccess: (ApiResult.Success<T>) -> C,

--- a/src/test/kotlin/com/slack/eithernet/ExtensionsTest.kt
+++ b/src/test/kotlin/com/slack/eithernet/ExtensionsTest.kt
@@ -16,9 +16,9 @@
 package com.slack.eithernet
 
 import com.google.common.truth.Truth.assertThat
+import kotlin.test.fail
 import okio.IOException
 import org.junit.Test
-import kotlin.test.fail
 
 @Suppress("ThrowsCount")
 class ExtensionsTest {

--- a/src/test/kotlin/com/slack/eithernet/ExtensionsTest.kt
+++ b/src/test/kotlin/com/slack/eithernet/ExtensionsTest.kt
@@ -18,6 +18,7 @@ package com.slack.eithernet
 import com.google.common.truth.Truth.assertThat
 import okio.IOException
 import org.junit.Test
+import kotlin.test.fail
 
 @Suppress("ThrowsCount")
 class ExtensionsTest {
@@ -128,5 +129,54 @@ class ExtensionsTest {
         onHttpFailure = { throw AssertionError() },
       )
     assertThat(folded).isEqualTo("Failure")
+  }
+
+  @Test
+  fun successOrNothingShouldEscape() {
+    val result: ApiResult<*, *> = ApiResult.networkFailure(IOException())
+    result.successOrNothing {
+      return
+    }
+    fail("Should not reach here")
+  }
+
+  @Test
+  fun exceptionOrNull_with_networkFailure() {
+    val exception = IOException()
+    val result = ApiResult.networkFailure(exception)
+    assertThat(result.exceptionOrNull()).isSameInstanceAs(exception)
+  }
+
+  @Test
+  fun exceptionOrNull_with_unknownFailure() {
+    val exception = IOException()
+    val result = ApiResult.unknownFailure(exception)
+    assertThat(result.exceptionOrNull()).isSameInstanceAs(exception)
+  }
+
+  @Test
+  fun exceptionOrNull_with_throwableApiFailure() {
+    val exception = IOException()
+    val result = ApiResult.apiFailure(exception)
+    assertThat(result.exceptionOrNull()).isSameInstanceAs(exception)
+  }
+
+  @Test
+  fun exceptionOrNull_with_throwableHttpFailure() {
+    val exception = IOException()
+    val result = ApiResult.httpFailure(404, exception)
+    assertThat(result.exceptionOrNull()).isSameInstanceAs(exception)
+  }
+
+  @Test
+  fun exceptionOrNull_with_nonThrowableApiFailure() {
+    val result = ApiResult.apiFailure("nope")
+    assertThat(result.exceptionOrNull()).isNull()
+  }
+
+  @Test
+  fun exceptionOrNull_with_nonThrowableHttpFailure() {
+    val result = ApiResult.httpFailure(404, "nope")
+    assertThat(result.exceptionOrNull()).isNull()
   }
 }


### PR DESCRIPTION
Couple more useful extensions for gracefully escaping or capturing underlying throwables. `exceptionOrNull()` is borrowed from the analogous function for `kotlin.Result`.