### PR TITLE
Misc extensions improvements

### DIFF
--- a/api/eithernet.api
+++ b/api/eithernet.api
@@ -72,8 +72,16 @@ public abstract interface annotation class com/slack/eithernet/ExperimentalEithe
 
 public final class com/slack/eithernet/ExtensionsKt {
 	public static final fun exceptionOrNull (Lcom/slack/eithernet/ApiResult$Failure;)Ljava/lang/Throwable;
-	public static final fun fold (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun fold (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final synthetic fun fold (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final synthetic fun fold (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun foldWithValue (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun foldWithValue (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun onApiFailure (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;)Lcom/slack/eithernet/ApiResult;
+	public static final fun onFailure (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;)Lcom/slack/eithernet/ApiResult;
+	public static final fun onHttpFailure (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;)Lcom/slack/eithernet/ApiResult;
+	public static final fun onNetworkFailure (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;)Lcom/slack/eithernet/ApiResult;
+	public static final fun onSuccess (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;)Lcom/slack/eithernet/ApiResult;
+	public static final fun onUnknownFailure (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;)Lcom/slack/eithernet/ApiResult;
 	public static final fun successOrElse (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun successOrNothing (Lcom/slack/eithernet/ApiResult;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun successOrNull (Lcom/slack/eithernet/ApiResult;)Ljava/lang/Object;

--- a/src/main/java/com/slack/eithernet/Extensions.kt
+++ b/src/main/java/com/slack/eithernet/Extensions.kt
@@ -77,7 +77,7 @@ public fun <E : Any> ApiResult.Failure<E>.exceptionOrNull(): Throwable? {
 }
 
 /** Transforms an [ApiResult] into a [C] value. */
-@Suppress("NOTHING_TO_INLINE") // Inline to allow
+@Suppress("NOTHING_TO_INLINE") // Inline to allow contextual actions
 public inline fun <T : Any, E : Any, C> ApiResult<T, E>.fold(
   noinline onSuccess: (ApiResult.Success<T>) -> C,
   noinline onFailure: (ApiResult.Failure<E>) -> C,
@@ -118,4 +118,76 @@ public inline fun <T : Any, E : Any, C> ApiResult<T, E>.fold(
     is ApiResult.Failure.NetworkFailure -> onNetworkFailure(this)
     is ApiResult.Failure.UnknownFailure -> onUnknownFailure(this)
   }
+}
+
+/**
+ * Performs the given [action] on the encapsulated [ApiResult.Failure] if this instance represents [failure][ApiResult.Failure].
+ * Returns the original `ApiResult` unchanged.
+ */
+public inline fun <T : Any, E : Any> ApiResult<T, E>.onFailure(action: (failure: ApiResult.Failure<E>) -> Unit): ApiResult<T, E> {
+  contract {
+    callsInPlace(action, InvocationKind.AT_MOST_ONCE)
+  }
+  if (this is ApiResult.Failure) action(this)
+  return this
+}
+
+/**
+ * Performs the given [action] on the encapsulated [ApiResult.Failure.HttpFailure] if this instance represents [failure][ApiResult.Failure.HttpFailure].
+ * Returns the original `ApiResult` unchanged.
+ */
+public inline fun <T : Any, E : Any> ApiResult<T, E>.onHttpFailure(action: (failure: ApiResult.Failure.HttpFailure<E>) -> Unit): ApiResult<T, E> {
+  contract {
+    callsInPlace(action, InvocationKind.AT_MOST_ONCE)
+  }
+  if (this is ApiResult.Failure.HttpFailure) action(this)
+  return this
+}
+
+/**
+ * Performs the given [action] on the encapsulated [ApiResult.Failure.ApiFailure] if this instance represents [failure][ApiResult.Failure.ApiFailure].
+ * Returns the original `ApiResult` unchanged.
+ */
+public inline fun <T : Any, E : Any> ApiResult<T, E>.onApiFailure(action: (failure: ApiResult.Failure.ApiFailure<E>) -> Unit): ApiResult<T, E> {
+  contract {
+    callsInPlace(action, InvocationKind.AT_MOST_ONCE)
+  }
+  if (this is ApiResult.Failure.ApiFailure) action(this)
+  return this
+}
+
+/**
+ * Performs the given [action] on the encapsulated [ApiResult.Failure.NetworkFailure] if this instance represents [failure][ApiResult.Failure.NetworkFailure].
+ * Returns the original `ApiResult` unchanged.
+ */
+public inline fun <T : Any, E : Any> ApiResult<T, E>.onNetworkFailure(action: (failure: ApiResult.Failure.NetworkFailure) -> Unit): ApiResult<T, E> {
+  contract {
+    callsInPlace(action, InvocationKind.AT_MOST_ONCE)
+  }
+  if (this is ApiResult.Failure.NetworkFailure) action(this)
+  return this
+}
+
+/**
+ * Performs the given [action] on the encapsulated [ApiResult.Failure.UnknownFailure] if this instance represents [failure][ApiResult.Failure.UnknownFailure].
+ * Returns the original `ApiResult` unchanged.
+ */
+public inline fun <T : Any, E : Any> ApiResult<T, E>.onUnknownFailure(action: (failure: ApiResult.Failure.UnknownFailure) -> Unit): ApiResult<T, E> {
+  contract {
+    callsInPlace(action, InvocationKind.AT_MOST_ONCE)
+  }
+  if (this is ApiResult.Failure.UnknownFailure) action(this)
+  return this
+}
+
+/**
+ * Performs the given [action] on the encapsulated value if this instance represents [success][ApiResult.Success].
+ * Returns the original `ApiResult` unchanged.
+ */
+public inline fun <T : Any, E : Any> ApiResult<T, E>.onSuccess(action: (value: T) -> Unit): ApiResult<T, E> {
+  contract {
+    callsInPlace(action, InvocationKind.AT_MOST_ONCE)
+  }
+  if (this is ApiResult.Success) action(value)
+  return this
 }

--- a/src/main/java/com/slack/eithernet/Extensions.kt
+++ b/src/main/java/com/slack/eithernet/Extensions.kt
@@ -35,9 +35,7 @@ public fun <T : Any, E : Any> ApiResult<T, E>.successOrNull(): T? =
 public inline fun <T : Any, E : Any> ApiResult<T, E>.successOrElse(
   defaultValue: (ApiResult.Failure<E>) -> T
 ): T {
-  contract {
-    callsInPlace(defaultValue, InvocationKind.AT_MOST_ONCE)
-  }
+  contract { callsInPlace(defaultValue, InvocationKind.AT_MOST_ONCE) }
   return when (this) {
     is ApiResult.Success -> value
     is ApiResult.Failure -> defaultValue(this)
@@ -51,9 +49,7 @@ public inline fun <T : Any, E : Any> ApiResult<T, E>.successOrElse(
 public inline fun <T : Any, E : Any> ApiResult<T, E>.successOrNothing(
   body: (ApiResult.Failure<E>) -> Nothing
 ): T {
-  contract {
-    callsInPlace(body, InvocationKind.AT_MOST_ONCE)
-  }
+  contract { callsInPlace(body, InvocationKind.AT_MOST_ONCE) }
   return when (this) {
     is ApiResult.Success -> value
     is ApiResult.Failure -> body(this)
@@ -121,73 +117,75 @@ public inline fun <T : Any, E : Any, C> ApiResult<T, E>.fold(
 }
 
 /**
- * Performs the given [action] on the encapsulated [ApiResult.Failure] if this instance represents [failure][ApiResult.Failure].
- * Returns the original `ApiResult` unchanged.
+ * Performs the given [action] on the encapsulated [ApiResult.Failure] if this instance represents
+ * [failure][ApiResult.Failure]. Returns the original `ApiResult` unchanged.
  */
-public inline fun <T : Any, E : Any> ApiResult<T, E>.onFailure(action: (failure: ApiResult.Failure<E>) -> Unit): ApiResult<T, E> {
-  contract {
-    callsInPlace(action, InvocationKind.AT_MOST_ONCE)
-  }
+public inline fun <T : Any, E : Any> ApiResult<T, E>.onFailure(
+  action: (failure: ApiResult.Failure<E>) -> Unit
+): ApiResult<T, E> {
+  contract { callsInPlace(action, InvocationKind.AT_MOST_ONCE) }
   if (this is ApiResult.Failure) action(this)
   return this
 }
 
 /**
- * Performs the given [action] on the encapsulated [ApiResult.Failure.HttpFailure] if this instance represents [failure][ApiResult.Failure.HttpFailure].
- * Returns the original `ApiResult` unchanged.
+ * Performs the given [action] on the encapsulated [ApiResult.Failure.HttpFailure] if this instance
+ * represents [failure][ApiResult.Failure.HttpFailure]. Returns the original `ApiResult` unchanged.
  */
-public inline fun <T : Any, E : Any> ApiResult<T, E>.onHttpFailure(action: (failure: ApiResult.Failure.HttpFailure<E>) -> Unit): ApiResult<T, E> {
-  contract {
-    callsInPlace(action, InvocationKind.AT_MOST_ONCE)
-  }
+public inline fun <T : Any, E : Any> ApiResult<T, E>.onHttpFailure(
+  action: (failure: ApiResult.Failure.HttpFailure<E>) -> Unit
+): ApiResult<T, E> {
+  contract { callsInPlace(action, InvocationKind.AT_MOST_ONCE) }
   if (this is ApiResult.Failure.HttpFailure) action(this)
   return this
 }
 
 /**
- * Performs the given [action] on the encapsulated [ApiResult.Failure.ApiFailure] if this instance represents [failure][ApiResult.Failure.ApiFailure].
- * Returns the original `ApiResult` unchanged.
+ * Performs the given [action] on the encapsulated [ApiResult.Failure.ApiFailure] if this instance
+ * represents [failure][ApiResult.Failure.ApiFailure]. Returns the original `ApiResult` unchanged.
  */
-public inline fun <T : Any, E : Any> ApiResult<T, E>.onApiFailure(action: (failure: ApiResult.Failure.ApiFailure<E>) -> Unit): ApiResult<T, E> {
-  contract {
-    callsInPlace(action, InvocationKind.AT_MOST_ONCE)
-  }
+public inline fun <T : Any, E : Any> ApiResult<T, E>.onApiFailure(
+  action: (failure: ApiResult.Failure.ApiFailure<E>) -> Unit
+): ApiResult<T, E> {
+  contract { callsInPlace(action, InvocationKind.AT_MOST_ONCE) }
   if (this is ApiResult.Failure.ApiFailure) action(this)
   return this
 }
 
 /**
- * Performs the given [action] on the encapsulated [ApiResult.Failure.NetworkFailure] if this instance represents [failure][ApiResult.Failure.NetworkFailure].
- * Returns the original `ApiResult` unchanged.
+ * Performs the given [action] on the encapsulated [ApiResult.Failure.NetworkFailure] if this
+ * instance represents [failure][ApiResult.Failure.NetworkFailure]. Returns the original `ApiResult`
+ * unchanged.
  */
-public inline fun <T : Any, E : Any> ApiResult<T, E>.onNetworkFailure(action: (failure: ApiResult.Failure.NetworkFailure) -> Unit): ApiResult<T, E> {
-  contract {
-    callsInPlace(action, InvocationKind.AT_MOST_ONCE)
-  }
+public inline fun <T : Any, E : Any> ApiResult<T, E>.onNetworkFailure(
+  action: (failure: ApiResult.Failure.NetworkFailure) -> Unit
+): ApiResult<T, E> {
+  contract { callsInPlace(action, InvocationKind.AT_MOST_ONCE) }
   if (this is ApiResult.Failure.NetworkFailure) action(this)
   return this
 }
 
 /**
- * Performs the given [action] on the encapsulated [ApiResult.Failure.UnknownFailure] if this instance represents [failure][ApiResult.Failure.UnknownFailure].
- * Returns the original `ApiResult` unchanged.
+ * Performs the given [action] on the encapsulated [ApiResult.Failure.UnknownFailure] if this
+ * instance represents [failure][ApiResult.Failure.UnknownFailure]. Returns the original `ApiResult`
+ * unchanged.
  */
-public inline fun <T : Any, E : Any> ApiResult<T, E>.onUnknownFailure(action: (failure: ApiResult.Failure.UnknownFailure) -> Unit): ApiResult<T, E> {
-  contract {
-    callsInPlace(action, InvocationKind.AT_MOST_ONCE)
-  }
+public inline fun <T : Any, E : Any> ApiResult<T, E>.onUnknownFailure(
+  action: (failure: ApiResult.Failure.UnknownFailure) -> Unit
+): ApiResult<T, E> {
+  contract { callsInPlace(action, InvocationKind.AT_MOST_ONCE) }
   if (this is ApiResult.Failure.UnknownFailure) action(this)
   return this
 }
 
 /**
- * Performs the given [action] on the encapsulated value if this instance represents [success][ApiResult.Success].
- * Returns the original `ApiResult` unchanged.
+ * Performs the given [action] on the encapsulated value if this instance represents
+ * [success][ApiResult.Success]. Returns the original `ApiResult` unchanged.
  */
-public inline fun <T : Any, E : Any> ApiResult<T, E>.onSuccess(action: (value: T) -> Unit): ApiResult<T, E> {
-  contract {
-    callsInPlace(action, InvocationKind.AT_MOST_ONCE)
-  }
+public inline fun <T : Any, E : Any> ApiResult<T, E>.onSuccess(
+  action: (value: T) -> Unit
+): ApiResult<T, E> {
+  contract { callsInPlace(action, InvocationKind.AT_MOST_ONCE) }
   if (this is ApiResult.Success) action(value)
   return this
 }

--- a/src/main/java/com/slack/eithernet/Extensions.kt
+++ b/src/main/java/com/slack/eithernet/Extensions.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 @file:OptIn(ExperimentalContracts::class)
+@file:Suppress("TooManyFunctions")
 
 package com.slack.eithernet
 

--- a/src/main/java/com/slack/eithernet/Extensions.kt
+++ b/src/main/java/com/slack/eithernet/Extensions.kt
@@ -194,19 +194,14 @@ public inline fun <T : Any, E : Any> ApiResult<T, E>.onSuccess(
 
 // Deprecated functions
 
-@Deprecated("Use fold instead", level = DeprecationLevel.HIDDEN)
+@Deprecated("Use fold instead, left for ABI compatibility", level = DeprecationLevel.HIDDEN)
 @JvmName("fold")
-@Suppress("NOTHING_TO_INLINE") // Inline to allow contextual actions
-public inline fun <T : Any, E : Any, C> ApiResult<T, E>.foldOld(
-  noinline onSuccess: (ApiResult.Success<T>) -> C,
-  noinline onFailure: (ApiResult.Failure<E>) -> C,
+public fun <T : Any, E : Any, C> ApiResult<T, E>.foldOld(
+  onSuccess: (ApiResult.Success<T>) -> C,
+  onFailure: (ApiResult.Failure<E>) -> C,
 ): C {
-  contract {
-    callsInPlace(onSuccess, InvocationKind.AT_MOST_ONCE)
-    callsInPlace(onFailure, InvocationKind.AT_MOST_ONCE)
-  }
   @Suppress("UNCHECKED_CAST")
-  return foldOld(
+  return foldOldInternal(
     onSuccess,
     onFailure as (ApiResult.Failure.NetworkFailure) -> C,
     onFailure as (ApiResult.Failure.UnknownFailure) -> C,
@@ -215,22 +210,32 @@ public inline fun <T : Any, E : Any, C> ApiResult<T, E>.foldOld(
   )
 }
 
-@Deprecated("Use fold instead", level = DeprecationLevel.HIDDEN)
+@Deprecated("Use fold instead, left for ABI compatibility", level = DeprecationLevel.HIDDEN)
 @JvmName("fold")
-public inline fun <T : Any, E : Any, C> ApiResult<T, E>.foldOld(
+public fun <T : Any, E : Any, C> ApiResult<T, E>.foldOld(
   onSuccess: (ApiResult.Success<T>) -> C,
   onNetworkFailure: (ApiResult.Failure.NetworkFailure) -> C,
   onUnknownFailure: (ApiResult.Failure.UnknownFailure) -> C,
   onHttpFailure: (ApiResult.Failure.HttpFailure<E>) -> C,
   onApiFailure: (ApiResult.Failure.ApiFailure<E>) -> C,
 ): C {
-  contract {
-    callsInPlace(onSuccess, InvocationKind.AT_MOST_ONCE)
-    callsInPlace(onNetworkFailure, InvocationKind.AT_MOST_ONCE)
-    callsInPlace(onUnknownFailure, InvocationKind.AT_MOST_ONCE)
-    callsInPlace(onHttpFailure, InvocationKind.AT_MOST_ONCE)
-    callsInPlace(onApiFailure, InvocationKind.AT_MOST_ONCE)
-  }
+  return foldOldInternal(
+    onSuccess,
+    onNetworkFailure,
+    onUnknownFailure,
+    onHttpFailure,
+    onApiFailure,
+  )
+}
+
+// Separate so we can call it from the two old deprecated versions above
+private fun <T : Any, E : Any, C> ApiResult<T, E>.foldOldInternal(
+  onSuccess: (ApiResult.Success<T>) -> C,
+  onNetworkFailure: (ApiResult.Failure.NetworkFailure) -> C,
+  onUnknownFailure: (ApiResult.Failure.UnknownFailure) -> C,
+  onHttpFailure: (ApiResult.Failure.HttpFailure<E>) -> C,
+  onApiFailure: (ApiResult.Failure.ApiFailure<E>) -> C,
+): C {
   return when (this) {
     is ApiResult.Success -> onSuccess(this)
     is ApiResult.Failure.ApiFailure -> onApiFailure(this)

--- a/src/main/java/com/slack/eithernet/Extensions.kt
+++ b/src/main/java/com/slack/eithernet/Extensions.kt
@@ -33,7 +33,7 @@ public fun <T : Any, E : Any> ApiResult<T, E>.successOrNull(): T? =
  * [defaultValue] function.
  */
 public inline fun <T : Any, E : Any> ApiResult<T, E>.successOrElse(
-  defaultValue: (ApiResult.Failure<E>) -> T
+  defaultValue: (failure: ApiResult.Failure<E>) -> T
 ): T {
   contract { callsInPlace(defaultValue, InvocationKind.AT_MOST_ONCE) }
   return when (this) {
@@ -47,7 +47,7 @@ public inline fun <T : Any, E : Any> ApiResult<T, E>.successOrElse(
  * failure, which can either throw an exception or return early (since this function is inline).
  */
 public inline fun <T : Any, E : Any> ApiResult<T, E>.successOrNothing(
-  body: (ApiResult.Failure<E>) -> Nothing
+  body: (failure: ApiResult.Failure<E>) -> Nothing
 ): T {
   contract { callsInPlace(body, InvocationKind.AT_MOST_ONCE) }
   return when (this) {
@@ -76,8 +76,8 @@ public fun <E : Any> ApiResult.Failure<E>.exceptionOrNull(): Throwable? {
 @Suppress("NOTHING_TO_INLINE") // Inline to allow contextual actions
 @JvmName("foldWithValue")
 public inline fun <T : Any, E : Any, C> ApiResult<T, E>.fold(
-  noinline onSuccess: (T) -> C,
-  noinline onFailure: (ApiResult.Failure<E>) -> C,
+  noinline onSuccess: (value: T) -> C,
+  noinline onFailure: (failure: ApiResult.Failure<E>) -> C,
 ): C {
   contract {
     callsInPlace(onSuccess, InvocationKind.AT_MOST_ONCE)
@@ -96,11 +96,11 @@ public inline fun <T : Any, E : Any, C> ApiResult<T, E>.fold(
 /** Transforms an [ApiResult] into a [C] value. */
 @JvmName("foldWithValue")
 public inline fun <T : Any, E : Any, C> ApiResult<T, E>.fold(
-  onSuccess: (T) -> C,
-  onNetworkFailure: (ApiResult.Failure.NetworkFailure) -> C,
-  onUnknownFailure: (ApiResult.Failure.UnknownFailure) -> C,
-  onHttpFailure: (ApiResult.Failure.HttpFailure<E>) -> C,
-  onApiFailure: (ApiResult.Failure.ApiFailure<E>) -> C,
+  onSuccess: (value: T) -> C,
+  onNetworkFailure: (failure: ApiResult.Failure.NetworkFailure) -> C,
+  onUnknownFailure: (failure: ApiResult.Failure.UnknownFailure) -> C,
+  onHttpFailure: (failure: ApiResult.Failure.HttpFailure<E>) -> C,
+  onApiFailure: (failure: ApiResult.Failure.ApiFailure<E>) -> C,
 ): C {
   contract {
     callsInPlace(onSuccess, InvocationKind.AT_MOST_ONCE)

--- a/src/test/kotlin/com/slack/eithernet/ExtensionsTest.kt
+++ b/src/test/kotlin/com/slack/eithernet/ExtensionsTest.kt
@@ -64,7 +64,7 @@ class ExtensionsTest {
   @Test
   fun foldSuccess() {
     val result = ApiResult.success("Hello")
-    val folded = result.fold({ it.value }, { "Failure" })
+    val folded = result.fold({ it }, { "Failure" })
     assertThat(folded).isEqualTo("Hello")
   }
 


### PR DESCRIPTION
This adds a number of improvements to extensions
- Deprecate old `fold()` functions and introduce new ones that use the underlying value rather than `Success`. This was an oversight in the previous implementation. Binary compatibility is preserved.
- Mark functions `inline` where possible to allow carried over context (i.e. in suspend functions, etc)
- Use contracts to inform the compiler about possible calls to lambdas.