### PR TITLE
Add out variance to ApiResult.Failure generic type

### DIFF
--- a/eithernet/api/eithernet.klib.api
+++ b/eithernet/api/eithernet.klib.api
@@ -69,7 +69,7 @@ sealed interface <#A: out kotlin/Any, #B: out kotlin/Any> com.slack.eithernet/Ap
         final fun networkFailure(okio/IOException): com.slack.eithernet/ApiResult.Failure.NetworkFailure // com.slack.eithernet/ApiResult.Companion.networkFailure|networkFailure(okio.IOException){}[0]
         final fun unknownFailure(kotlin/Throwable): com.slack.eithernet/ApiResult.Failure.UnknownFailure // com.slack.eithernet/ApiResult.Companion.unknownFailure|unknownFailure(kotlin.Throwable){}[0]
     }
-    sealed interface <#A1: kotlin/Any> Failure : com.slack.eithernet/ApiResult<kotlin/Nothing, #A1> { // com.slack.eithernet/ApiResult.Failure|null[0]
+    sealed interface <#A1: out kotlin/Any> Failure : com.slack.eithernet/ApiResult<kotlin/Nothing, #A1> { // com.slack.eithernet/ApiResult.Failure|null[0]
         final class <#A2: kotlin/Any> ApiFailure : com.slack.eithernet/ApiResult.Failure<#A2> { // com.slack.eithernet/ApiResult.Failure.ApiFailure|null[0]
             final fun withTags(kotlin.collections/Map<kotlin.reflect/KClass<*>, kotlin/Any>): com.slack.eithernet/ApiResult.Failure.ApiFailure<#A2> // com.slack.eithernet/ApiResult.Failure.ApiFailure.withTags|withTags(kotlin.collections.Map<kotlin.reflect.KClass<*>,kotlin.Any>){}[0]
             final val error // com.slack.eithernet/ApiResult.Failure.ApiFailure.error|{}error[0]

--- a/eithernet/src/commonMain/kotlin/com/slack/eithernet/ApiResult.kt
+++ b/eithernet/src/commonMain/kotlin/com/slack/eithernet/ApiResult.kt
@@ -65,7 +65,7 @@ public sealed interface ApiResult<out T : Any, out E : Any> {
   }
 
   /** Represents a failure of some sort. */
-  public sealed interface Failure<E : Any> : ApiResult<Nothing, E> {
+  public sealed interface Failure<out E : Any> : ApiResult<Nothing, E> {
 
     /**
      * A network failure caused by a given [error]. This error is opaque, as the actual type could


### PR DESCRIPTION
###  Summary

Add `out` variance to `ApiResult.Failure<E>` to make subtypes implementing `Failure<Nothing>` such as `NetworkFailure` conform to `Failure<*>`

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/eithernet/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).